### PR TITLE
Throw error when write fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,3 +27,4 @@
 - [FIXED] An issue where an empty batch could be written to the backup file.
 - [FIXED] An issue where the restore-time buffer size was ignored.
 - [FIXED] Ensure body 'rows' key exists before performing shallow backup.
+- [FIXED] An issue where write errors were not correctly reported.

--- a/app.js
+++ b/app.js
@@ -108,6 +108,13 @@ module.exports = {
 
     const ee = new events.EventEmitter();
 
+    // if there is an error writing to the stream, call the completion
+    // callback with the error set
+    targetStream.on('error', function(obj) {
+      debug('Error ' + JSON.stringify(obj));
+      if (callback) callback(obj, null);
+    });
+
     // If resuming write a newline as it's possible one would be missing from
     // an interruption of the previous backup. If the backup was clean this
     // will cause an empty line that will be gracefully handled by the restore.

--- a/citest/test.js
+++ b/citest/test.js
@@ -322,3 +322,26 @@ describe('Event tests', function() {
     });
   });
 });
+
+describe('Write error tests', function() {
+  it('calls callback with error set when stream is not writeable', function(done) {
+    u.timeoutFilter(this, 10);
+    const dirname = fs.mkdtempSync('test_backup');
+    // make temp dir not writeable
+    fs.chmodSync(dirname, 0);
+    const filename = dirname + '/test.backup';
+    const backupStream = fs.createWriteStream(filename, {flags:'w'});
+    const params = {useApi: true};
+    // try to do backup and check err was set in callback
+    const backup = u.testBackup(params, 'animaldb', backupStream, function(err) {
+      // error should have been set
+      assert.ok(err != null);
+      // cleanup temp dir
+      fs.chmodSync(dirname, 0x1B6); // 666 in octal
+      fs.rmdirSync(dirname);
+      done();
+    });
+  });
+});
+
+

--- a/citest/test.js
+++ b/citest/test.js
@@ -330,10 +330,10 @@ describe('Write error tests', function() {
     // make temp dir not writeable
     fs.chmodSync(dirname, 0);
     const filename = dirname + '/test.backup';
-    const backupStream = fs.createWriteStream(filename, {flags:'w'});
+    const backupStream = fs.createWriteStream(filename, {flags: 'w'});
     const params = {useApi: true};
     // try to do backup and check err was set in callback
-    const backup = u.testBackup(params, 'animaldb', backupStream, function(err) {
+    u.testBackup(params, 'animaldb', backupStream, function(err) {
       // error should have been set
       assert.ok(err != null);
       assert.equal(err.code, 'EACCES');
@@ -344,5 +344,3 @@ describe('Write error tests', function() {
     });
   });
 });
-
-

--- a/citest/test.js
+++ b/citest/test.js
@@ -334,13 +334,17 @@ describe('Write error tests', function() {
     const params = {useApi: true};
     // try to do backup and check err was set in callback
     u.testBackup(params, 'animaldb', backupStream, function(err) {
-      // error should have been set
-      assert.ok(err != null);
-      assert.equal(err.code, 'EACCES');
-      // cleanup temp dir
-      fs.chmodSync(dirname, 0x1B6); // 666 in octal
-      fs.rmdirSync(dirname);
-      done();
+      try {
+        // cleanup temp dir
+        fs.chmodSync(dirname, 0x1B6); // 666 in octal
+        fs.rmdirSync(dirname);
+        // error should have been set
+        assert.ok(err != null);
+        assert.equal(err.code, 'EACCES');
+        done();
+      } catch (err) {
+        done(err);
+      }
     });
   });
 });

--- a/citest/test.js
+++ b/citest/test.js
@@ -336,6 +336,7 @@ describe('Write error tests', function() {
     const backup = u.testBackup(params, 'animaldb', backupStream, function(err) {
       // error should have been set
       assert.ok(err != null);
+      assert.equal(err.code, 'EACCES');
       // cleanup temp dir
       fs.chmodSync(dirname, 0x1B6); // 666 in octal
       fs.rmdirSync(dirname);


### PR DESCRIPTION
Related to #61, this PR addresses cases where we're writing to a stream and not a file, so it's not possible to check if it is writable before starting. Instead, make sure that the callback is called with the correct error