### PR TITLE
79 fix unreliable network tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,59 +24,59 @@ def getEnv(envName) {
 
   // Add test suite specific environment variables
   switch(envName) {
-  case 'test-default':
-    envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-    envVars.add("TEST_TIMEOUT_LIMIT_SECS=900")
-    break
-  case 'toxy-default':
-    envVars.add("COUCH_URL=http://localhost:3000") // proxy
-    envVars.add("TEST_PROXY_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-    envVars.add("TEST_TIMEOUT_LIMIT_SECS=3600") // 1hr
-    envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
-    break
-  default:
-    error("Unknown test suite environment ${envName}")
+    case 'test-default':
+      envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+      envVars.add("TEST_TIMEOUT_LIMIT_SECS=900")
+      break
+    case 'toxy-default':
+      envVars.add("COUCH_URL=http://localhost:3000") // proxy
+      envVars.add("TEST_PROXY_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+      envVars.add("TEST_TIMEOUT_LIMIT_SECS=3600") // 1hr
+      envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
+      break
+    default:
+      error("Unknown test suite environment ${envName}")
   }
 
   return envVars
 }
 
 def setupNodeAndTest(version, testSuite='test', envName='default') {
-    node {
-        // Install NVM
-        sh 'wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash'
-        // Unstash the built content
-        unstash name: 'built'
+  node {
+    // Install NVM
+    sh 'wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash'
+    // Unstash the built content
+    unstash name: 'built'
 
-        // Run tests using creds
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'],
-                         [$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactory', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PW']]) {
-          withEnv(getEnv("${testSuite}-${envName}")) {
-            try {
-              // Actions:
-              //  - Load NVM
-              //  - Install/use required Node.js version
-              //  - Install mocha-junit-reporter so that we can get junit style output
-              //  - Run unit tests
-              //  - Fetch database compare tool for CI tests
-              //  - Run test suite
-              sh """
-                [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                nvm install ${version}
-                nvm use ${version}
-                npm install mocha-junit-reporter --save-dev
-                ./node_modules/mocha/bin/mocha test --reporter mocha-junit-reporter --reporter-options mochaFile=./test/unit-test-results.xml
-                cd citest
-                curl -O -u ${env.ARTIFACTORY_USER}:${env.ARTIFACTORY_PW} https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
-                unzip ${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
-                ../node_modules/mocha/bin/mocha ${testSuite} --reporter mocha-junit-reporter --reporter-options mochaFile=./ci-${testSuite}-results.xml
-              """
-            } finally {
-              junit '**/*test-results.xml'
-            }
-          }
+    // Run tests using creds
+    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'],
+                     [$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactory', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PW']]) {
+      withEnv(getEnv("${testSuite}-${envName}")) {
+        try {
+          // Actions:
+          //  1. Load NVM
+          //  2. Install/use required Node.js version
+          //  3. Install mocha-junit-reporter so that we can get junit style output
+          //  4. Run unit tests
+          //  5. Fetch database compare tool for CI tests
+          //  6. Run test suite
+          sh """
+            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+            nvm install ${version}
+            nvm use ${version}
+            npm install mocha-junit-reporter --save-dev
+            ./node_modules/mocha/bin/mocha test --reporter mocha-junit-reporter --reporter-options mochaFile=./test/unit-test-results.xml
+            cd citest
+            curl -O -u ${env.ARTIFACTORY_USER}:${env.ARTIFACTORY_PW} https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+            unzip ${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+            ../node_modules/mocha/bin/mocha ${testSuite} --reporter mocha-junit-reporter --reporter-options mochaFile=./ci-${testSuite}-results.xml
+          """
+        } finally {
+          junit '**/*test-results.xml'
         }
+      }
     }
+  }
 }
 
 String getVersionFromPackageJson() {
@@ -88,14 +88,14 @@ String version = null;
 boolean isReleaseVersion = false;
 
 stage('Build') {
-    // Checkout, build
-    node {
-        checkout scm
-        version = getVersionFromPackageJson();
-        isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains('SNAPSHOT')
-        sh 'npm install'
-        stash name: 'built'
-    }
+  // Checkout, build
+  node {
+    checkout scm
+    version = getVersionFromPackageJson();
+    isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains('SNAPSHOT')
+    sh 'npm install'
+    stash name: 'built'
+  }
 }
 
 stage('QA') {
@@ -114,56 +114,56 @@ stage('QA') {
 
 // Publish the master branch
 stage('Publish') {
-    if (env.BRANCH_NAME == "master") {
-        node {
-            checkout scm // re-checkout to be able to git tag
+  if (env.BRANCH_NAME == "master") {
+    node {
+      checkout scm // re-checkout to be able to git tag
 
-            // Upload using the ossrh creds (upload destination logic is in build.gradle)
-            withCredentials([string(credentialsId: 'npm-mail', variable: 'NPM_EMAIL'),
-            usernamePassword(credentialsId: 'npm-creds', passwordVariable: 'NPM_PASS', usernameVariable: 'NPM_USER')]) {
-                // Actions:
-                // 1. add the build ID to any snapshot version for uniqueness
-                // 2. install login helper
-                // 3. login to npm, using environment variables specified above
-                // 4. publish the build to NPM adding a snapshot tag if pre-release
-                sh """
-                  ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
-                  sudo npm install -g npm-cli-login
-                  npm-cli-login
-                  npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
-                """
-            }
+      // Upload using the ossrh creds (upload destination logic is in build.gradle)
+      withCredentials([string(credentialsId: 'npm-mail', variable: 'NPM_EMAIL'),
+                       usernamePassword(credentialsId: 'npm-creds', passwordVariable: 'NPM_PASS', usernameVariable: 'NPM_USER')]) {
+        // Actions:
+        // 1. add the build ID to any snapshot version for uniqueness
+        // 2. install login helper
+        // 3. login to npm, using environment variables specified above
+        // 4. publish the build to NPM adding a snapshot tag if pre-release
+        sh """
+          ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
+          sudo npm install -g npm-cli-login
+          npm-cli-login
+          npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
+        """
+      }
 
-            // if it is a release build then do the git tagging
-            if (isReleaseVersion) {
+      // if it is a release build then do the git tagging
+      if (isReleaseVersion) {
 
-                // Read the CHANGES.md to get the tag message
-                tagMessage = ''
-                for (line in readFile('CHANGES.md').readLines()) {
-                    if (!''.equals(line)) {
-                        // append the line to the tagMessage
-                        tagMessage = "${tagMessage}${line}\n"
-                    } else {
-                        break
-                    }
-                }
-
-                // Use git to tag the release at the version
-                try {
-                    // Awkward workaround until resolution of https://issues.jenkins-ci.org/browse/JENKINS-28335
-                    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'github-token', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD']]) {
-                        sh "git config user.email \"nomail@hursley.ibm.com\""
-                        sh "git config user.name \"Jenkins CI\""
-                        sh "git config credential.username ${env.GIT_USERNAME}"
-                        sh "git config credential.helper '!echo password=\$GIT_PASSWORD; echo'"
-                        sh "git tag -a ${version} -m '${tagMessage}'"
-                        sh "git push origin ${version}"
-                    }
-                } finally {
-                    sh "git config --unset credential.username"
-                    sh "git config --unset credential.helper"
-                }
-            }
+        // Read the CHANGES.md to get the tag message
+        tagMessage = ''
+        for (line in readFile('CHANGES.md').readLines()) {
+          if (!''.equals(line)) {
+            // append the line to the tagMessage
+            tagMessage = "${tagMessage}${line}\n"
+          } else {
+            break
+          }
         }
+
+        // Use git to tag the release at the version
+        try {
+          // Awkward workaround until resolution of https://issues.jenkins-ci.org/browse/JENKINS-28335
+          withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'github-token', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD']]) {
+            sh "git config user.email \"nomail@hursley.ibm.com\""
+            sh "git config user.name \"Jenkins CI\""
+            sh "git config credential.username ${env.GIT_USERNAME}"
+            sh "git config credential.helper '!echo password=\$GIT_PASSWORD; echo'"
+            sh "git tag -a ${version} -m '${tagMessage}'"
+            sh "git push origin ${version}"
+          }
+        } finally {
+          sh "git config --unset credential.username"
+          sh "git config --unset credential.helper"
+        }
+      }
     }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,6 @@ def getEnv(envName) {
       break
     case 'toxy-default':
       envVars.add("COUCH_URL=http://localhost:3000") // proxy
-      envVars.add("TEST_PROXY_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
       envVars.add("TEST_TIMEOUT_LIMIT_SECS=3600") // 1hr
       envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
       break

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,29 +14,31 @@
 // limitations under the License.
 
 def getEnv(envName) {
-    // Base environment variables
-    def envVars = [
-      "COUCH_URL_COMPARE=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
-      "DBCOMPARE_NAME=DatabaseCompare",
-      "DBCOMPARE_VERSION=1.0.0",
-      "NVM_DIR=${env.HOME}/.nvm",
-      "TEST_LIMIT=900"
-    ]
+  // Base environment variables
+  def envVars = [
+    "COUCH_URL_COMPARE=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
+    "DBCOMPARE_NAME=DatabaseCompare",
+    "DBCOMPARE_VERSION=1.0.0",
+    "NVM_DIR=${env.HOME}/.nvm"
+  ]
 
-    // Add test suite specific environment variables
-    switch(envName) {
-      case 'test-default':
-        envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-        break
-      case 'toxy-default':
-        envVars.add("COUCH_URL=http://localhost:3000") // proxy
-        envVars.add("TEST_PROXY_BACKEND=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-        break
-      default:
-        error("Unknown test suite environment ${envName}")
-    }
+  // Add test suite specific environment variables
+  switch(envName) {
+  case 'test-default':
+    envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+    envVars.add("TEST_TIMEOUT_LIMIT=900")
+    break
+  case 'toxy-default':
+    envVars.add("COUCH_URL=http://localhost:3000") // proxy
+    envVars.add("TEST_PROXY_BACKEND=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+    envVars.add("TEST_TIMEOUT_LIMIT=3600") // 1hr
+    envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
+    break
+  default:
+    error("Unknown test suite environment ${envName}")
+  }
 
-    return envVars
+  return envVars
 }
 
 def setupNodeAndTest(version, testSuite='test', envName='default') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 def getEnv(envName) {
   // Base environment variables
   def envVars = [
-    "COUCH_URL_COMPARE=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
+    "COUCH_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
     "DBCOMPARE_NAME=DatabaseCompare",
     "DBCOMPARE_VERSION=1.0.0",
     "NVM_DIR=${env.HOME}/.nvm"
@@ -26,12 +26,12 @@ def getEnv(envName) {
   switch(envName) {
   case 'test-default':
     envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-    envVars.add("TEST_TIMEOUT_LIMIT=900")
+    envVars.add("TEST_TIMEOUT_LIMIT_SECS=900")
     break
   case 'toxy-default':
     envVars.add("COUCH_URL=http://localhost:3000") // proxy
-    envVars.add("TEST_PROXY_BACKEND=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
-    envVars.add("TEST_TIMEOUT_LIMIT=3600") // 1hr
+    envVars.add("TEST_PROXY_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+    envVars.add("TEST_TIMEOUT_LIMIT_SECS=3600") // 1hr
     envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
     break
   default:

--- a/citest/citestutils.js
+++ b/citest/citestutils.js
@@ -17,7 +17,7 @@
 
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const cloudant = require('cloudant')({url: process.env.COUCH_URL});
+const cloudant = require('cloudant')({url: process.env.COUCH_URL_COMPARE});
 const app = require('../app.js');
 const dbUrl = require('../includes/cliutils.js').databaseUrl;
 const stream = require('stream');

--- a/citest/citestutils.js
+++ b/citest/citestutils.js
@@ -442,8 +442,11 @@ function readSortAndDeepEqual(actualContentPath, expectedContentPath, callback) 
 
 function timeoutFilter(context, timeout) {
   // Default to a limit of 1 minute for tests
-  const limit = (typeof process.env.TEST_LIMIT !== 'undefined') ? parseInt(process.env.TEST_LIMIT) : 60;
+  const limit = (typeof process.env.TEST_TIMEOUT_LIMIT !== 'undefined') ? parseInt(process.env.TEST_TIMEOUT_LIMIT) : 60;
   timeout = (!timeout) ? 60 : timeout;
+  // Increase timeout using TEST_TIMEOUT_MULTIPLIER
+  const multiplier = (typeof process.env.TEST_TIMEOUT_MULTIPLIER !== 'undefined') ? parseInt(process.env.TEST_TIMEOUT_MULTIPLIER) : 1;
+  timeout *= multiplier;
   if (timeout <= limit) {
     // Set the mocha timeout
     context.timeout(timeout * 1000);

--- a/citest/citestutils.js
+++ b/citest/citestutils.js
@@ -17,7 +17,7 @@
 
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const cloudant = require('cloudant')({url: process.env.COUCH_URL_COMPARE});
+const cloudant = require('cloudant')({url: process.env.COUCH_BACKEND_URL});
 const app = require('../app.js');
 const dbUrl = require('../includes/cliutils.js').databaseUrl;
 const stream = require('stream');
@@ -403,7 +403,7 @@ function testBackupAbortResumeRestore(params, srcDb, backupFile, targetDb, callb
 
 function dbCompare(db1Name, db2Name, callback) {
   const comparison = spawn(`./${process.env.DBCOMPARE_NAME}-${process.env.DBCOMPARE_VERSION}/bin/${process.env.DBCOMPARE_NAME}`,
-    [process.env.COUCH_URL_COMPARE, db1Name, process.env.COUCH_URL_COMPARE, db2Name], {'stdio': 'inherit'});
+    [process.env.COUCH_BACKEND_URL, db1Name, process.env.COUCH_BACKEND_URL, db2Name], {'stdio': 'inherit'});
   comparison.on('exit', function(code) {
     try {
       assert.equal(code, 0, `The database comparison should succeed, got exit code ${code}`);
@@ -442,7 +442,7 @@ function readSortAndDeepEqual(actualContentPath, expectedContentPath, callback) 
 
 function timeoutFilter(context, timeout) {
   // Default to a limit of 1 minute for tests
-  const limit = (typeof process.env.TEST_TIMEOUT_LIMIT !== 'undefined') ? parseInt(process.env.TEST_TIMEOUT_LIMIT) : 60;
+  const limit = (typeof process.env.TEST_TIMEOUT_LIMIT_SECS !== 'undefined') ? parseInt(process.env.TEST_TIMEOUT_LIMIT_SECS) : 60;
   timeout = (!timeout) ? 60 : timeout;
   // Increase timeout using TEST_TIMEOUT_MULTIPLIER
   const multiplier = (typeof process.env.TEST_TIMEOUT_MULTIPLIER !== 'undefined') ? parseInt(process.env.TEST_TIMEOUT_MULTIPLIER) : 1;

--- a/citest/test.js
+++ b/citest/test.js
@@ -17,6 +17,8 @@
 
 const assert = require('assert');
 const fs = require('fs');
+
+delete require.cache[require.resolve('./citestutils.js')];
 const u = require('./citestutils.js');
 
 [{useApi: true}, {useApi: false}].forEach(function(params) {

--- a/citest/toxy.js
+++ b/citest/toxy.js
@@ -23,27 +23,27 @@ const trules = toxy.rules;
 
 function setupProxy(poison) {
   var proxy = toxy({
-    auth: url.parse(process.env.TEST_PROXY_BACKEND_URL).auth,
+    auth: url.parse(process.env.COUCH_BACKEND_URL).auth,
     changeOrigin: true
   });
 
   switch (poison) {
     case 'normal':
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND_URL)
+        .forward(process.env.COUCH_BACKEND_URL)
         .all('/*');
       break;
     case 'bandwidth-limit':
       // https://github.com/h2non/toxy#bandwidth
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND_URL)
+        .forward(process.env.COUCH_BACKEND_URL)
         .poison(tpoisons.bandwidth({ bps: 256 * 1024 })) // 256 kB/s
         .all('/*');
       break;
     case 'latency':
       // https://github.com/h2non/toxy#latency
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND_URL)
+        .forward(process.env.COUCH_BACKEND_URL)
         .poison(tpoisons.latency({ max: 10000, min: 100 }))
         .withRule(trules.probability(50))
         .all('/*');
@@ -51,7 +51,7 @@ function setupProxy(poison) {
     case 'slow-read':
       // https://github.com/h2non/toxy#slow-read
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND_URL)
+        .forward(process.env.COUCH_BACKEND_URL)
         .poison(tpoisons.slowRead({ bps: 1024, threshold: 100 }))
         .withRule(trules.probability(50))
         .all('/*');
@@ -79,7 +79,7 @@ poisons.forEach(function(poison) {
       console.log('Using toxy poison ' + poison);
 
       // For these tests COUCH_URL points to the toxy proxy on localhost whereas
-      // TEST_PROXY_BACKEND_URL is the real CouchDb instance.
+      // COUCH_BACKEND_URL is the real CouchDb instance.
 
       proxy.listen(url.parse(process.env.COUCH_URL).port);
     });

--- a/citest/toxy.js
+++ b/citest/toxy.js
@@ -123,6 +123,7 @@ poisons.forEach(function(poison) {
       proxy.close();
     });
 
+    delete require.cache[require.resolve('./test.js')];
     require('./test.js');
   });
 });

--- a/citest/toxy.js
+++ b/citest/toxy.js
@@ -23,27 +23,27 @@ const trules = toxy.rules;
 
 function setupProxy(poison) {
   var proxy = toxy({
-    auth: url.parse(process.env.TEST_PROXY_BACKEND).auth,
+    auth: url.parse(process.env.TEST_PROXY_BACKEND_URL).auth,
     changeOrigin: true
   });
 
   switch (poison) {
     case 'normal':
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND)
+        .forward(process.env.TEST_PROXY_BACKEND_URL)
         .all('/*');
       break;
     case 'bandwidth-limit':
       // https://github.com/h2non/toxy#bandwidth
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND)
+        .forward(process.env.TEST_PROXY_BACKEND_URL)
         .poison(tpoisons.bandwidth({ bps: 256 * 1024 })) // 256 kB/s
         .all('/*');
       break;
     case 'latency':
       // https://github.com/h2non/toxy#latency
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND)
+        .forward(process.env.TEST_PROXY_BACKEND_URL)
         .poison(tpoisons.latency({ max: 10000, min: 100 }))
         .withRule(trules.probability(50))
         .all('/*');
@@ -51,7 +51,7 @@ function setupProxy(poison) {
     case 'slow-read':
       // https://github.com/h2non/toxy#slow-read
       proxy
-        .forward(process.env.TEST_PROXY_BACKEND)
+        .forward(process.env.TEST_PROXY_BACKEND_URL)
         .poison(tpoisons.slowRead({ bps: 1024, threshold: 100 }))
         .withRule(trules.probability(50))
         .all('/*');
@@ -79,7 +79,7 @@ poisons.forEach(function(poison) {
       console.log('Using toxy poison ' + poison);
 
       // For these tests COUCH_URL points to the toxy proxy on localhost whereas
-      // TEST_PROXY_BACKEND is the real CouchDb instance.
+      // TEST_PROXY_BACKEND_URL is the real CouchDb instance.
 
       proxy.listen(url.parse(process.env.COUCH_URL).port);
     });


### PR DESCRIPTION
## What
Add following poisons to toxy tests:
- bandwidth-limit
- latency
- slow-read

The remaining poisons (namely `abort`, `rate-limit` & `unexpected-errors`) will be implemented in a future PR as additional retrying logic is required.

_'[test] make test release build' commit to be removed prior to merge._

## How
Uncomment poisons and introduce TEST_TIMEOUT_MULTIPLIER to ensure toxy tests don't timeout.

## Issues
Fixes #79.
