### PR TITLE
Remove retain argument in s3-backup-stream.js

### DIFF
--- a/examples/s3-backup-stream.js
+++ b/examples/s3-backup-stream.js
@@ -38,7 +38,6 @@ function main() {
     .options({
       'source': {alias: 's', nargs: 1, demandOption: true, describe: 'Source database URL'},
       'bucket': {alias: 'b', nargs: 1, demandOption: true, describe: 'Destination bucket'},
-      'retain': {alias: 'r', nargs: 1, describe: 'Retain N newest backups', number: true, default: 5},
       'prefix': {alias: 'p', nargs: 1, describe: 'Prefix for backup object key', default: 'couchbackup'},
       's3url': {nargs: 1, describe: 'S3 endpoint URL'},
       'awsprofile': {nargs: 1, describe: 'The profile section to use in the ~/.aws/credentials file', default: 'default'}


### PR DESCRIPTION
This was remanent from a very basic feature I used in my own backup
scripts to clean up old backups. However, it wasn't at all suitable
for wider use.

#98
