### PR TITLE
Improve error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
   server.
 - [IMPROVED] Added HTTP persistent connection pools corresponding to the backup
   parallelism.
+- [IMPROVED] Better error handling in couchrestore when remote database
+  cannot be written to.
 - [FIXED] An issue where the process could exit before the backup content was
   completely flushed to the destination stream.
 - [FIXED] An issue where back pressure on the output stream was ignored

--- a/app.js
+++ b/app.js
@@ -201,20 +201,22 @@ module.exports = {
         if (err) {
           callback(err, null);
         }
-
-        writer.on('restored', function(obj) {
-          debug(' restored ', obj.total);
-          ee.emit('restored', {documents: obj.documents, total: obj.total});
-        })
-        .on('error', function(e) {
-          debug(' error', e);
-          ee.emit('error', e);
-        })
-        .on('finished', function(obj) {
-          debug('restore complete');
-          ee.emit('finished', {total: obj.total});
-          callback(null, obj);
-        });
+        if (writer != null) {
+          writer.on('restored', function(obj) {
+            debug(' restored ', obj.total);
+            ee.emit('restored', {documents: obj.documents, total: obj.total});
+          })
+          .on('error', function(e) {
+            debug(' error', e);
+            ee.emit('error', e);
+            callback(e, writer);
+          })
+          .on('finished', function(obj) {
+            debug('restore complete');
+            ee.emit('finished', {total: obj.total});
+            callback(null, obj);
+          });
+        }
       }
     );
 

--- a/includes/error.js
+++ b/includes/error.js
@@ -26,6 +26,7 @@ module.exports = {
         var exitCode = {
           'InvalidOption': 2,
           'RestoreDatabaseNotFound': 10,
+          'Unauthorized': 11,
           'NoLogFileName': 20,
           'LogDoesNotExist': 21
         }[err.name] || 1;


### PR DESCRIPTION
See #22 

**What**

Abort processing for fatal errors when doing restore:

- Throw fatal error if the candidate restore database doesn't exist (HEAD returns 404)
- Throw fatal error if unexpected return code is obtained after doing HEAD on candidate restore database
- Throw fatal error if a 401 is encountered when trying to write to the database
- Stop processing queue and other threads if fatal errors are encountered

**How**

Make `writer` emit `error` events and then call the error callback as appropriate.

Make `exists` more robust.

**Testing**

Manual testing restoring to a database without `_writer` permissions:
```
$ COUCH_URL=https://tomblench.cloudant.com COUCH_DATABASE=airportdb_backup  ./bin/couchrestore.bin.js < out 
...
Database https://tomblench.cloudant.com/airportdb_backup does not have correct permissions. Check that you have the correct permssions before restoring.
```

Manual testing restoring to a database which does not exist:
```
COUCH_URL=https://tomblench.cloudant.com COUCH_DATABASE=nonexistent  ./bin/couchrestore.bin.js < out 
...
Database https://tomblench.cloudant.com/nonexistent does not exist. Create the target database before restoring.
```

Manual testing restoring to a database without `_reader` permissions:
```
COUCH_URL=https://tomblench.cloudant.com COUCH_DATABASE=airportdb_backup  ./bin/couchrestore.bin.js < out 
...
HEAD https://tomblench.cloudant.com/airportdb_backup returned error code 401
```
