### PR TITLE
Terminate on spool changes failure

### DIFF
--- a/includes/backup.js
+++ b/includes/backup.js
@@ -48,8 +48,12 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
   if (resume) {
     downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
   } else {
-    spoolchanges(dbUrl, log, blocksize, function logFileGenerated() {
-      downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+    spoolchanges(dbUrl, log, blocksize, function(err) {
+      if (err) {
+        ee.emit('error', err);
+      } else {
+        downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+      }
     });
   }
 

--- a/includes/error.js
+++ b/includes/error.js
@@ -13,6 +13,18 @@
 // limitations under the License.
 'use strict';
 
+// fatal errors
+const codes = {
+  'InvalidOption': 2,
+  'RestoreDatabaseNotFound': 10,
+  'Unauthorized': 11,
+  'Forbidden': 12,
+  'NoLogFileName': 20,
+  'LogDoesNotExist': 21,
+  'IncompleteChangesInLogFile': 22,
+  'SpoolChangesError': 30
+};
+
 module.exports = {
   BackupError: class BackupError extends Error {
     constructor(name, message) {
@@ -20,18 +32,12 @@ module.exports = {
       this.name = name;
     }
   },
+  codes: function() { return Object.assign({}, codes); },
   terminationCallback: function terminationCallback(err, data) {
     if (err) {
       process.on('uncaughtException', function(err) {
-        var exitCode = {
-          'InvalidOption': 2,
-          'RestoreDatabaseNotFound': 10,
-          'Unauthorized': 11,
-          'NoLogFileName': 20,
-          'LogDoesNotExist': 21
-        }[err.name] || 1;
         console.error(err.message);
-        process.exitCode = exitCode;
+        process.exitCode = codes[err.name] || 1;
       });
       throw err;
     }


### PR DESCRIPTION
## What
Terminate on spool changes failure, for example:
```
$ couchbackup --url http://localhost:3000/ --db animaldb
================================================================================
Performing backup on http://localhost:3000/animaldb using configuration:
{
  "bufferSize": 500,
  "log": "/var/folders/5p/11lmsvwn5l91cn7ysrs4nm1r0000gn/T/tmp-79048fCiWkfAJefLd.tmp",
  "mode": "full",
  "parallelism": 5
}
================================================================================
Changes request failed with status code 500
$ echo $?
30
```

## How
Ensure `resp.statusCode == 200` prior to processing changes body.

## Issues
Fixes #103.
