### PR TITLE
Limit backup /_bulk_get attempts

### DIFF
--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -57,7 +57,7 @@ return couchbackup.backup(
   opts,
   error.terminationCallback
 ).on('written', function(obj) {
-  debug('written', obj.batch, ' docs: ', obj.total, 'Time', obj.time);
+  debug('written batch:', obj.batch, 'total docs now written:', obj.total, 'time:', obj.time);
 }).on('error', function(e) {
   debug('ERROR', e);
 }).on('finished', function(obj) {

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -22,6 +22,8 @@ const spoolchanges = require('./spoolchanges.js');
 const logfilesummary = require('./logfilesummary.js');
 const logfilegetbatches = require('./logfilegetbatches.js');
 
+var client;
+
 /**
  * Read documents from a database to be backed up.
  *
@@ -41,18 +43,19 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
   }
   const ee = new events.EventEmitter();
   const start = new Date().getTime();  // backup start time
-  const batchesPerDownloadSession = 50;  // max batches to read from log file for download at a time (prevent OOM)
 
-  // If resuming, pick up from existing log file from previous run. Otherwise,
-  // create new log file and process from that.
+  client = request.client(dbUrl, parallelism);
+
   if (resume) {
-    downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+    // pick up from existing log file from previous run
+    downloadBatches(log, dbUrl, ee, start, parallelism);
   } else {
+    // create new log file and process
     spoolchanges(dbUrl, log, blocksize, function(err) {
       if (err) {
         ee.emit('error', err);
       } else {
-        downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+        downloadBatches(log, dbUrl, ee, start, parallelism);
       }
     });
   }
@@ -61,168 +64,154 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
 };
 
 /**
- * Download remaining batches in a log file, splitting batches into sets
- * to avoid enqueueing too many in one go.
+ * Download batches in a log file.
  *
  * @param {string} log - log file name to maintain download state
  * @param {string} dbUrl - Source database URL
  * @param {events.EventEmitter} ee - event emitter to emit received events on
  * @param {time} start - start time for backup process
- * @param {number} batchesPerDownloadSession - max batches to enqueue for
- *  download at a time. As batches contain many doc IDs, this helps avoid
- *  exhausting memory.
  * @param {number} parallelism - number of concurrent downloads
- * @returns function to call do download remaining batches with signature
- *  (err, {batches: batch, docs: doccount}) {@see spoolchanges}.
+ * @param {function} callback - called once complete with signature is (err,
+ * total documents downloaded number)
  */
-function downloadRemainingBatches(log, dbUrl, ee, startTime, batchesPerDownloadSession, parallelism) {
-  var total = 0;  // running total of documents downloaded so far
-  var noRemainingBatches = false;
+function downloadBatches(log, dbUrl, ee, startTime, parallelism, callback) {
+  readAllBatchIdsFromLogFile(log, function(err, allBatchIds) {
+    if (err) return ee.emit('error', err);
+    if (allBatchIds.length === 0) return ee.emit('finished', {total: 0});
 
-  // Generate a set of batches (up to batchesPerDownloadSession) to download from the
-  // log file and download them. Set noRemainingBatches to `true` for last batch.
-  function downloadSingleBatchSet(done) {
-    readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, ee, function(err, batchSetIds) {
-      if (batchSetIds.length === 0) {
-        noRemainingBatches = true;
-        return done();
-      }
+    var total = 0;
+    const maxBatchFetch = 50;
+    var hasErrored = false;
 
-      // Fetch the doc IDs for the batches in the current set to
-      // download and download them.
-      function batchSetComplete(err, data) {
-        total = data.total;
-        done();
-      }
-      function processRetrievedBatches(err, batches) {
-        // process them in parallelised queue
-        processBatchSet(dbUrl, parallelism, log, batches, ee, startTime, total, batchSetComplete);
-      }
-      logfilegetbatches(log, batchSetIds, processRetrievedBatches);
-    });
-  }
-
-  // Return true if all batches in log file have been downloaded
-  function isFinished() { return noRemainingBatches; }
-
-  function onComplete() {
-    ee.emit('finished', {total: total});
-  }
-
-  async.doUntil(downloadSingleBatchSet, isFinished, onComplete);
-}
-
-/**
- * Return a set of uncompleted download batch IDs from the log file.
- *
- * @param {string} log - log file path
- * @param {number} batchesPerDownloadSession - maximum IDs to return
- * @param {any} ee - emit `error` event if log file invalid
- * @param {function} callback - sign (err, batchSetIds array)
- */
-function readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, ee, callback) {
-  logfilesummary(log, function processSummary(err, summary) {
-    if (!summary.changesComplete) {
-      ee.emit('error', new error.BackupError(
-        'IncompleteChangesInLogFile',
-        'WARNING: Changes did not finish spooling'
-        ));
-    }
-    if (Object.keys(summary.batches).length === 0) {
-      return callback(null, []);
+    function process(done) {
+      logfilegetbatches(log, allBatchIds.splice(0, maxBatchFetch).map(Number), function(err, batches) {
+        processBatches(dbUrl, parallelism, log, batches, ee, startTime, total, function(err, newTotal) {
+          total = newTotal;
+          if (err) {
+            hasErrored = true;
+            done(err, total);
+          } else {
+            done(null, total);
+          }
+        });
+      });
     }
 
-    // batch IDs are the property names of summary.batches
-    var batchSetIds = getPropertyNames(summary.batches, batchesPerDownloadSession);
-    callback(null, batchSetIds);
+    function isComplete() {
+      return hasErrored || allBatchIds.length === 0;
+    }
+
+    function onComplete(err, total) {
+      if (err) {
+        ee.emit('error', err);
+      } else {
+        ee.emit('finished', {total: total});
+      }
+    }
+
+    async.doUntil(process, isComplete, onComplete);
   });
 }
 
 /**
- * Download a set of batches retrieved from a log file. When a download is
- * complete, add a line to the logfile indicating such.
+ * Return all uncompleted download batch IDs from the log file.
+ *
+ * @param {string} log - log file path
+ * @param {function} callback - called once complete with signature is (err,
+ * batchSetIds array)
+ */
+function readAllBatchIdsFromLogFile(log, callback) {
+  logfilesummary(log, function(err, summary) {
+    if (!summary.changesComplete) {
+      callback(new error.BackupError('IncompleteChangesInLogFile', 'WARNING: Changes did not finish spooling'));
+    } else {
+      callback(null, Object.keys(summary.batches));
+    }
+  });
+}
+
+/**
+ * Download a batch retrieved from a log file. When a download is complete, add
+ * a line to the logfile indicating such.
  *
  * @param {any} dbUrl - URL of database
  * @param {any} parallelism - number of concurrent requests to make
  * @param {any} log - log file to drive downloads from
  * @param {any} batches - batches to download
- * @param {any} ee - event emitter for progress. This funciton emits
- *  received and error events.
+ * @param {any} ee - event emitter for progress. This funciton emits received
+ *  and error events.
  * @param {any} start - time backup started, to report deltas
- * @param {any} grandtotal - count of documents downloaded prior to this set
- *  of batches
- * @param {any} callback - completion callback, (err, {total: number}).
+ * @param {any} total - count of documents downloaded
+ * @param {function} callback - called once complete with signature (err, total)
+ * where total is the number of documents downloaded
  */
-function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal, callback) {
-  const client = request.client(dbUrl, parallelism);
-  var total = grandtotal;
+function processBatches(dbUrl, parallelism, log, batches, ee, start, total, callback) {
+  var q = async.queue(function(batch, done) {
+    function doBulkGet(callback) {
+      var r = {
+        url: dbUrl + '/_bulk_get',
+        qs: { revs: true },
+        method: 'post',
+        body: {docs: batch.docs}
+      };
 
-  // queue to process the fetch requests in an orderly fashion using _bulk_get
-  var q = async.queue(function(payload, done) {
-    var output = [];
-    var thisBatch = payload.batch;
-    delete payload.batch;
+      client(r, function(err, res, data) {
+        if (err) {
+          callback(err);
+        } else if (res.statusCode !== 200) {
+          callback(new error.BackupError('BackupRetrieveError', `ERROR: Failed to get document batch ${batch.batch}, status code ${res.statusCode}`));
+        } else if (!data || !data.results) {
+          callback(new error.BackupError('BackupRetrieveError', `ERROR: Received invalid bulk get response for document batch ${batch.batch}`));
+        } else {
+          var output = [];
+          data.results.forEach(function(d) {
+            if (d.docs) {
+              d.docs.forEach(function(doc) {
+                if (doc.ok) {
+                  output.push(doc.ok);
+                }
+              });
+            }
+          });
+          callback(null, output);
+        }
+      });
+    }
 
     function logCompletedBatch(batch) {
       if (log) {
-        fs.appendFile(log, ':d batch' + thisBatch + '\n', done);
+        fs.appendFile(log, ':d batch' + batch + '\n', done);
       } else {
         done();
       }
     }
 
-    // do the /db/_bulk_get request
-    var r = {
-      url: dbUrl + '/_bulk_get',
-      qs: { revs: true }, // gets previous revision tokens too
-      method: 'post',
-      body: payload
-    };
-    client(r, function(err, res, data) {
-      if (!err && data && data.results) {
-        // create an output array with the docs returned
-        data.results.forEach(function(d) {
-          if (d.docs) {
-            d.docs.forEach(function(doc) {
-              if (doc.ok) {
-                output.push(doc.ok);
-              }
-            });
-          }
-        });
-        total += output.length;
-        var t = (new Date().getTime() - start) / 1000;
-        ee.emit('received', {length: output.length, time: t, total: total, data: output, batch: thisBatch}, q, logCompletedBatch);
-      } else {
+    async.retry(3, doBulkGet, function(err, results) {
+      if (err) {
         ee.emit('error', err);
         done();
+      } else {
+        var docCount = results.length;
+        total += docCount;
+
+        var data = {
+          length: docCount,
+          time: (new Date().getTime() - start) / 1000,
+          total: total,
+          data: results,
+          batch: batch.batch
+        };
+
+        ee.emit('received', data, q, logCompletedBatch);
       }
     });
   }, parallelism);
 
+  // add batches to work queue
   for (var i in batches) {
     q.push(batches[i]);
   }
 
-  q.drain = function() {
-    callback(null, {total: total});
-  };
-}
-
-/**
- * Returns first N properties on an object.
- *
- * @param {object} obj - object with properties
- * @param {number} count - number of properties to return
- */
-function getPropertyNames(obj, count) {
-  // decide which batch numbers to deal with
-  var batchestofetch = [];
-  var j = 0;
-  for (var i in obj) {
-    batchestofetch.push(parseInt(i));
-    j++;
-    if (j >= count) break;
-  }
-  return batchestofetch;
+  // callback with new total once complete
+  q.drain = function() { callback(null, total); };
 }


### PR DESCRIPTION
## What
Add a max. retry limit of 3 for all backup '/_bulk_get' requests.

Since failed backup '/_bulk_get' requests now don't need re-adding to the work queue, we don't need to re-read the log file on every iteration.

## How
Use `async.retry` to retry '/_bulk_get' requests  on failure.

## Issues
Fixes #111 .
