### PR TITLE
Fetch document revisions individually if bulk get isn't supported

### DIFF
--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -57,7 +57,7 @@ return couchbackup.backup(
   opts,
   error.terminationCallback
 ).on('written', function(obj) {
-  debug('written', obj.batch, ' docs: ', obj.total, 'Time', obj.time);
+  debug('written batch:', obj.batch, 'total docs now written:', obj.total, 'time:', obj.time);
 }).on('error', function(e) {
   debug('ERROR', e);
 }).on('finished', function(obj) {

--- a/citest/test.js
+++ b/citest/test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* global describe it */
+/* global describe it after before */
 'use strict';
 
 const assert = require('assert');
@@ -23,113 +23,155 @@ const u = require('./citestutils.js');
 
 [{useApi: true}, {useApi: false}].forEach(function(params) {
   describe(u.scenario('Basic backup and restore', params), function() {
-    it('should backup animaldb to a file correctly', function(done) {
-      // Allow up to 40 s to backup and compare (it should be much faster)!
-      u.timeoutFilter(this, 40);
-      const actualBackup = `./${this.fileName}`;
-      // Create a file and backup to it
-      const output = fs.createWriteStream(actualBackup);
-      output.on('open', function() {
-        u.testBackup(params, 'animaldb', output, function(err) {
-          if (err) {
-            done(err);
-          } else {
-            u.readSortAndDeepEqual(actualBackup, './animaldb_expected.json', done);
-          }
+    describe('Unsupported /_bulk_get endpoint', function() {
+      before(function() {
+        process.env.TEST_SUPPORT_BULK_GET = 'false';
+      });
+
+      after(function() {
+        delete process.env.TEST_SUPPORT_BULK_GET;
+      });
+
+      it('should backup animaldb to a file correctly', function(done) {
+        // Allow up to 60 s to backup and compare
+        u.timeoutFilter(this, 60);
+        const actualBackup = `./${this.fileName}`;
+        // Create a file and backup to it
+        const output = fs.createWriteStream(actualBackup);
+        output.on('open', function() {
+          u.testBackup(params, 'animaldb', output, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.readSortAndDeepEqual(actualBackup, './animaldb_expected.json', done);
+            }
+          });
         });
       });
     });
 
-    it('should restore animaldb to a database correctly', function(done) {
-      // Allow up to 60 s to restore and compare (again it should be faster)!
-      u.timeoutFilter(this, 60);
-      const input = fs.createReadStream('animaldb_expected.json');
-      const dbName = this.dbName;
-      input.on('open', function() {
-        u.testRestore(params, input, dbName, function(err) {
-          if (err) {
-            done(err);
-          } else {
-            u.dbCompare('animaldb', dbName, done);
-          }
+    describe('Check for /_bulk_get support', function() {
+      it('should backup animaldb to a file correctly', function(done) {
+        // Allow up to 40 s to backup and compare (it should be much faster)!
+        u.timeoutFilter(this, 40);
+        const actualBackup = `./${this.fileName}`;
+        // Create a file and backup to it
+        const output = fs.createWriteStream(actualBackup);
+        output.on('open', function() {
+          u.testBackup(params, 'animaldb', output, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.readSortAndDeepEqual(actualBackup, './animaldb_expected.json', done);
+            }
+          });
+        });
+      });
+
+      it('should restore animaldb to a database correctly', function(done) {
+        // Allow up to 60 s to restore and compare (again it should be faster)!
+        u.timeoutFilter(this, 60);
+        const input = fs.createReadStream('animaldb_expected.json');
+        const dbName = this.dbName;
+        input.on('open', function() {
+          u.testRestore(params, input, dbName, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.dbCompare('animaldb', dbName, done);
+            }
+          });
+        });
+      });
+
+      it('should restore corrupted animaldb to a database correctly', function(done) {
+        // Allow up to 60 s to restore and compare (again it should be faster)!
+        u.timeoutFilter(this, 60);
+        const input = fs.createReadStream('animaldb_corrupted.json');
+        const dbName = this.dbName;
+        input.on('open', function() {
+          u.testRestore(params, input, dbName, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.dbCompare('animaldb', dbName, done);
+            }
+          });
+        });
+      });
+
+      it('should restore resumed animaldb with blank line to a database correctly', function(done) {
+        // Allow up to 60 s to restore and compare (again it should be faster)!
+        u.timeoutFilter(this, 60);
+        const input = fs.createReadStream('animaldb_resumed_blank.json');
+        const dbName = this.dbName;
+        input.on('open', function() {
+          u.testRestore(params, input, dbName, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.dbCompare('animaldb', dbName, done);
+            }
+          });
+        });
+      });
+
+      it('should execute a shallow mode backup successfully', function(done) {
+        // Allow 30 s
+        u.timeoutFilter(this, 30);
+        const actualBackup = `./${this.fileName}`;
+        const output = fs.createWriteStream(actualBackup);
+        // Add the shallow mode option
+        const p = u.p(params, {opts: {mode: 'shallow'}});
+        output.on('open', function() {
+          u.testBackup(p, 'animaldb', output, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.readSortAndDeepEqual(actualBackup, './animaldb_expected_shallow.json', done);
+            }
+          });
         });
       });
     });
 
-    it('should restore corrupted animaldb to a database correctly', function(done) {
-      // Allow up to 60 s to restore and compare (again it should be faster)!
-      u.timeoutFilter(this, 60);
-      const input = fs.createReadStream('animaldb_corrupted.json');
-      const dbName = this.dbName;
-      input.on('open', function() {
-        u.testRestore(params, input, dbName, function(err) {
-          if (err) {
-            done(err);
-          } else {
-            u.dbCompare('animaldb', dbName, done);
-          }
-        });
+    describe(u.scenario('End to end backup and restore', params), function() {
+      it('should backup and restore animaldb', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        u.testDirectBackupAndRestore(params, 'animaldb', this.dbName, done);
+      });
+      it('should backup and restore largedb1g', function(done) {
+        // Allow up to 15 m for backup and restore of largedb1g
+        u.timeoutFilter(this, 15 * 60);
+        u.testDirectBackupAndRestore(params, 'largedb1g', this.dbName, done);
       });
     });
 
-    it('should restore resumed animaldb with blank line to a database correctly', function(done) {
-      // Allow up to 60 s to restore and compare (again it should be faster)!
-      u.timeoutFilter(this, 60);
-      const input = fs.createReadStream('animaldb_resumed_blank.json');
-      const dbName = this.dbName;
-      input.on('open', function() {
-        u.testRestore(params, input, dbName, function(err) {
-          if (err) {
-            done(err);
-          } else {
-            u.dbCompare('animaldb', dbName, done);
-          }
+    describe(u.scenario('Compression tests', params), function() {
+      const p = u.p(params, {compression: true});
+
+      it('should backup animaldb to a compressed file', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 40);
+        const compressedBackup = `./${this.fileName}`;
+        const output = fs.createWriteStream(compressedBackup);
+        output.on('open', function() {
+          u.testBackup(p, 'animaldb', output, function(err) {
+            if (err) {
+              done(err);
+            } else {
+              u.assertGzipFile(compressedBackup, done);
+            }
+          });
         });
       });
-    });
 
-    it('should execute a shallow mode backup successfully', function(done) {
-      // Allow 30 s
-      u.timeoutFilter(this, 30);
-      const actualBackup = `./${this.fileName}`;
-      const output = fs.createWriteStream(actualBackup);
-      // Add the shallow mode option
-      const p = u.p(params, {opts: {mode: 'shallow'}});
-      output.on('open', function() {
-        u.testBackup(p, 'animaldb', output, function(err) {
-          if (err) {
-            done(err);
-          } else {
-            u.readSortAndDeepEqual(actualBackup, './animaldb_expected_shallow.json', done);
-          }
-        });
-      });
-    });
-  });
-
-  describe(u.scenario('End to end backup and restore', params), function() {
-    it('should backup and restore animaldb', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
-      u.testDirectBackupAndRestore(params, 'animaldb', this.dbName, done);
-    });
-    it('should backup and restore largedb1g', function(done) {
-      // Allow up to 15 m for backup and restore of largedb1g
-      u.timeoutFilter(this, 15 * 60);
-      u.testDirectBackupAndRestore(params, 'largedb1g', this.dbName, done);
-    });
-  });
-
-  describe(u.scenario('Compression tests', params), function() {
-    const p = u.p(params, {compression: true});
-
-    it('should backup animaldb to a compressed file', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 40);
-      const compressedBackup = `./${this.fileName}`;
-      const output = fs.createWriteStream(compressedBackup);
-      output.on('open', function() {
-        u.testBackup(p, 'animaldb', output, function(err) {
+      it('should backup and restore animaldb via a compressed file', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        const compressedBackup = `./${this.fileName}`;
+        u.testBackupAndRestoreViaFile(p, 'animaldb', compressedBackup, this.dbName, function(err) {
           if (err) {
             done(err);
           } else {
@@ -137,178 +179,142 @@ const u = require('./citestutils.js');
           }
         });
       });
-    });
 
-    it('should backup and restore animaldb via a compressed file', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
-      const compressedBackup = `./${this.fileName}`;
-      u.testBackupAndRestoreViaFile(p, 'animaldb', compressedBackup, this.dbName, function(err) {
-        if (err) {
-          done(err);
-        } else {
-          u.assertGzipFile(compressedBackup, done);
-        }
+      it('should backup and restore animaldb via a compressed stream', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        u.testDirectBackupAndRestore(p, 'animaldb', this.dbName, done);
+      });
+
+      it('should backup and restore largedb2g via a compressed file', function(done) {
+        // Categorize as a 30 min test so it only gets run with the long run tests
+        u.timeoutFilter(this, 30 * 60);
+        const compressedBackup = `./${this.fileName}`;
+        params.compression = true;
+        u.testBackupAndRestoreViaFile(p, 'largedb2g', compressedBackup, this.dbName, done);
+      });
+    });
+    describe(u.scenario('Resume tests', params), function() {
+      it('should create a log file', function(done) {
+        // Allow up to 90 s for this test
+        u.timeoutFilter(this, 60);
+
+        const actualBackup = `./${this.fileName}`;
+        const logFile = `./${this.fileName}` + '.log';
+        // Use abort parameter to terminate the backup a given number of ms after
+        // the first data write to the output file.
+        const p = u.p(params, {opts: {log: logFile}});
+        u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
+          if (err) {
+            done(err);
+          } else {
+            // Assert the log file exists
+            try {
+              assert.ok(fs.existsSync(logFile), 'The log file should exist.');
+              done();
+            } catch (err) {
+              done(err);
+            }
+          }
+        });
       });
     });
 
-    it('should backup and restore animaldb via a compressed stream', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
-      u.testDirectBackupAndRestore(p, 'animaldb', this.dbName, done);
-    });
-
-    it('should backup and restore largedb2g via a compressed file', function(done) {
-      // Categorize as a 30 min test so it only gets run with the long run tests
-      u.timeoutFilter(this, 30 * 60);
-      const compressedBackup = `./${this.fileName}`;
-      params.compression = true;
-      u.testBackupAndRestoreViaFile(p, 'largedb2g', compressedBackup, this.dbName, done);
+    describe(u.scenario('Buffer size tests', params), function() {
+      it('should backup/restore animaldb with the same buffer size', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        const actualBackup = `./${this.fileName}`;
+        const logFile = `./${this.fileName}` + '.log';
+        const p = u.p(params, {opts: {log: logFile, bufferSize: 1}});
+        u.testBackupAndRestoreViaFile(p, 'animaldb', actualBackup, this.dbName, done);
+      });
+      it('should backup/restore animaldb with backup buffer > restore buffer', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        const actualBackup = `./${this.fileName}`;
+        const logFile = `./${this.fileName}` + '.log';
+        const dbName = this.dbName;
+        const p = u.p(params, {opts: {log: logFile, bufferSize: 2}}); // backup
+        const q = u.p(params, {opts: {bufferSize: 1}}); // restore
+        u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
+          if (err) {
+            done(err);
+          } else {
+            // restore
+            u.testRestoreFromFile(q, actualBackup, dbName, function(err) {
+              u.dbCompare('animaldb', dbName, done);
+            });
+          }
+        });
+      });
+      it('should backup/restore animaldb with backup buffer < restore buffer', function(done) {
+        // Allow up to 60 s for backup and restore of animaldb
+        u.timeoutFilter(this, 60);
+        const actualBackup = `./${this.fileName}`;
+        const logFile = `./${this.fileName}` + '.log';
+        const dbName = this.dbName;
+        const p = u.p(params, {opts: {log: logFile, bufferSize: 1}}); // backup
+        const q = u.p(params, {opts: {bufferSize: 2}}); // restore
+        u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
+          if (err) {
+            done(err);
+          } else {
+            // restore
+            u.testRestoreFromFile(q, actualBackup, dbName, function(err) {
+              u.dbCompare('animaldb', dbName, done);
+            });
+          }
+        });
+      });
     });
   });
-  describe(u.scenario('Resume tests', params), function() {
-    it('should create a log file', function(done) {
+
+  describe('Resume tests', function() {
+    // Currently cannot abort API backups, when we do this test should be run for
+    // both API and CLI
+    it('should correctly backup and restore backup10m', function(done) {
       // Allow up to 90 s for this test
-      u.timeoutFilter(this, 60);
+      u.timeoutFilter(this, 90);
 
       const actualBackup = `./${this.fileName}`;
       const logFile = `./${this.fileName}` + '.log';
       // Use abort parameter to terminate the backup a given number of ms after
       // the first data write to the output file.
-      const p = u.p(params, {opts: {log: logFile}});
-      u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
-        if (err) {
-          done(err);
-        } else {
-          // Assert the log file exists
-          try {
-            assert.ok(fs.existsSync(logFile), 'The log file should exist.');
-            done();
-          } catch (err) {
-            done(err);
-          }
-        }
-      });
-    });
-  });
+      const p = u.p(params, {abort: true}, {opts: {log: logFile}});
+      const restoreDb = this.dbName;
+      // Set the database doc count as fewer than this should be written during
+      // resumed backup.
+      p.exclusiveMaxExpected = 5096;
 
-  describe(u.scenario('Buffer size tests', params), function() {
-    it('should backup/restore animaldb with the same buffer size', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
+      u.testBackupAbortResumeRestore(p, 'backup10m', actualBackup, restoreDb, done);
+    });
+    // Note --output is only valid for CLI usage, this test should only run for CLI
+    const params = {useApi: false};
+    it('should correctly backup and restore backup10m using --output', function(done) {
+      // Allow up to 90 s for this test
+      u.timeoutFilter(this, 90);
+
       const actualBackup = `./${this.fileName}`;
       const logFile = `./${this.fileName}` + '.log';
-      const p = u.p(params, {opts: {log: logFile, bufferSize: 1}});
-      u.testBackupAndRestoreViaFile(p, 'animaldb', actualBackup, this.dbName, done);
-    });
-    it('should backup/restore animaldb with backup buffer > restore buffer', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
-      const actualBackup = `./${this.fileName}`;
-      const logFile = `./${this.fileName}` + '.log';
-      const dbName = this.dbName;
-      const p = u.p(params, {opts: {log: logFile, bufferSize: 2}}); // backup
-      const q = u.p(params, {opts: {bufferSize: 1}}); // restore
-      u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
-        if (err) {
-          done(err);
-        } else {
-          // restore
-          u.testRestoreFromFile(q, actualBackup, dbName, function(err) {
-            u.dbCompare('animaldb', dbName, done);
-          });
-        }
-      });
-    });
-    it('should backup/restore animaldb with backup buffer < restore buffer', function(done) {
-      // Allow up to 60 s for backup and restore of animaldb
-      u.timeoutFilter(this, 60);
-      const actualBackup = `./${this.fileName}`;
-      const logFile = `./${this.fileName}` + '.log';
-      const dbName = this.dbName;
-      const p = u.p(params, {opts: {log: logFile, bufferSize: 1}}); // backup
-      const q = u.p(params, {opts: {bufferSize: 2}}); // restore
-      u.testBackupToFile(p, 'animaldb', actualBackup, function(err) {
-        if (err) {
-          done(err);
-        } else {
-          // restore
-          u.testRestoreFromFile(q, actualBackup, dbName, function(err) {
-            u.dbCompare('animaldb', dbName, done);
-          });
-        }
-      });
+      // Use abort parameter to terminate the backup a given number of ms after
+      // the first data write to the output file.
+      const p = u.p(params, {abort: true}, {opts: {output: actualBackup, log: logFile}});
+      const restoreDb = this.dbName;
+      // Set the database doc count as fewer than this should be written during
+      // resumed backup.
+      p.exclusiveMaxExpected = 5096;
+
+      u.testBackupAbortResumeRestore(p, 'backup10m', actualBackup, restoreDb, done);
     });
   });
-});
 
-describe('Resume tests', function() {
-  // Currently cannot abort API backups, when we do this test should be run for
-  // both API and CLI
-  it('should correctly backup and restore backup10m', function(done) {
-    // Allow up to 90 s for this test
-    u.timeoutFilter(this, 90);
-
-    const actualBackup = `./${this.fileName}`;
-    const logFile = `./${this.fileName}` + '.log';
-    // Use abort parameter to terminate the backup a given number of ms after
-    // the first data write to the output file.
-    const p = u.p(params, {abort: true}, {opts: {log: logFile}});
-    const restoreDb = this.dbName;
-    // Set the database doc count as fewer than this should be written during
-    // resumed backup.
-    p.exclusiveMaxExpected = 5096;
-
-    u.testBackupAbortResumeRestore(p, 'backup10m', actualBackup, restoreDb, done);
-  });
-  // Note --output is only valid for CLI usage, this test should only run for CLI
-  const params = {useApi: false};
-  it('should correctly backup and restore backup10m using --output', function(done) {
-    // Allow up to 90 s for this test
-    u.timeoutFilter(this, 90);
-
-    const actualBackup = `./${this.fileName}`;
-    const logFile = `./${this.fileName}` + '.log';
-    // Use abort parameter to terminate the backup a given number of ms after
-    // the first data write to the output file.
-    const p = u.p(params, {abort: true}, {opts: {output: actualBackup, log: logFile}});
-    const restoreDb = this.dbName;
-    // Set the database doc count as fewer than this should be written during
-    // resumed backup.
-    p.exclusiveMaxExpected = 5096;
-
-    u.testBackupAbortResumeRestore(p, 'backup10m', actualBackup, restoreDb, done);
-  });
-});
-
-describe('Event tests', function() {
-  it('should get a finished event when using stdout', function(done) {
-    u.timeoutFilter(this, 40);
-    // Use the API so we can get events
-    const params = {useApi: true};
-    const backup = u.testBackup(params, 'animaldb', process.stdout, function(err) {
-      if (err) {
-        done(err);
-      }
-    });
-    backup.on('finished', function() {
-      try {
-        // Test will time out if the finished event is not emitted
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
-  });
-  it('should get a finished event when using file output', function(done) {
-    u.timeoutFilter(this, 40);
-    // Use the API so we can get events
-    const params = {useApi: true};
-    const actualBackup = `./${this.fileName}`;
-    // Create a file and backup to it
-    const output = fs.createWriteStream(actualBackup);
-    output.on('open', function() {
-      const backup = u.testBackup(params, 'animaldb', output, function(err) {
+  describe('Event tests', function() {
+    it('should get a finished event when using stdout', function(done) {
+      u.timeoutFilter(this, 40);
+      // Use the API so we can get events
+      const params = {useApi: true};
+      const backup = u.testBackup(params, 'animaldb', process.stdout, function(err) {
         if (err) {
           done(err);
         }
@@ -320,6 +326,29 @@ describe('Event tests', function() {
         } catch (err) {
           done(err);
         }
+      });
+    });
+    it('should get a finished event when using file output', function(done) {
+      u.timeoutFilter(this, 40);
+      // Use the API so we can get events
+      const params = {useApi: true};
+      const actualBackup = `./${this.fileName}`;
+      // Create a file and backup to it
+      const output = fs.createWriteStream(actualBackup);
+      output.on('open', function() {
+        const backup = u.testBackup(params, 'animaldb', output, function(err) {
+          if (err) {
+            done(err);
+          }
+        });
+        backup.on('finished', function() {
+          try {
+            // Test will time out if the finished event is not emitted
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
       });
     });
   });

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -22,6 +22,8 @@ const spoolchanges = require('./spoolchanges.js');
 const logfilesummary = require('./logfilesummary.js');
 const logfilegetbatches = require('./logfilegetbatches.js');
 
+var client;
+
 /**
  * Read documents from a database to be backed up.
  *
@@ -41,18 +43,19 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
   }
   const ee = new events.EventEmitter();
   const start = new Date().getTime();  // backup start time
-  const batchesPerDownloadSession = 50;  // max batches to read from log file for download at a time (prevent OOM)
 
-  // If resuming, pick up from existing log file from previous run. Otherwise,
-  // create new log file and process from that.
+  client = request.client(dbUrl, parallelism);
+
   if (resume) {
-    downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+    // pick up from existing log file from previous run
+    downloadBatches(log, dbUrl, ee, start, parallelism);
   } else {
+    // create new log file and process
     spoolchanges(dbUrl, log, blocksize, function(err) {
       if (err) {
         ee.emit('error', err);
       } else {
-        downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
+        downloadBatches(log, dbUrl, ee, start, parallelism);
       }
     });
   }
@@ -61,168 +64,154 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
 };
 
 /**
- * Download remaining batches in a log file, splitting batches into sets
- * to avoid enqueueing too many in one go.
+ * Download batches in a log file.
  *
  * @param {string} log - log file name to maintain download state
  * @param {string} dbUrl - Source database URL
  * @param {events.EventEmitter} ee - event emitter to emit received events on
  * @param {time} start - start time for backup process
- * @param {number} batchesPerDownloadSession - max batches to enqueue for
- *  download at a time. As batches contain many doc IDs, this helps avoid
- *  exhausting memory.
  * @param {number} parallelism - number of concurrent downloads
- * @returns function to call do download remaining batches with signature
- *  (err, {batches: batch, docs: doccount}) {@see spoolchanges}.
+ * @param {function} callback - called once complete with signature is (err,
+ * total documents downloaded number)
  */
-function downloadRemainingBatches(log, dbUrl, ee, startTime, batchesPerDownloadSession, parallelism) {
-  var total = 0;  // running total of documents downloaded so far
-  var noRemainingBatches = false;
+function downloadBatches(log, dbUrl, ee, startTime, parallelism, callback) {
+  readAllBatchIdsFromLogFile(log, function(err, allBatchIds) {
+    if (err) return ee.emit('error', err);
+    if (allBatchIds.length === 0) return ee.emit('finished', {total: 0});
 
-  // Generate a set of batches (up to batchesPerDownloadSession) to download from the
-  // log file and download them. Set noRemainingBatches to `true` for last batch.
-  function downloadSingleBatchSet(done) {
-    readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, ee, function(err, batchSetIds) {
-      if (batchSetIds.length === 0) {
-        noRemainingBatches = true;
-        return done();
-      }
+    var total = 0;
+    const maxBatchFetch = 50;
+    var hasErrored = false;
 
-      // Fetch the doc IDs for the batches in the current set to
-      // download and download them.
-      function batchSetComplete(err, data) {
-        total = data.total;
-        done();
-      }
-      function processRetrievedBatches(err, batches) {
-        // process them in parallelised queue
-        processBatchSet(dbUrl, parallelism, log, batches, ee, startTime, total, batchSetComplete);
-      }
-      logfilegetbatches(log, batchSetIds, processRetrievedBatches);
-    });
-  }
-
-  // Return true if all batches in log file have been downloaded
-  function isFinished() { return noRemainingBatches; }
-
-  function onComplete() {
-    ee.emit('finished', {total: total});
-  }
-
-  async.doUntil(downloadSingleBatchSet, isFinished, onComplete);
-}
-
-/**
- * Return a set of uncompleted download batch IDs from the log file.
- *
- * @param {string} log - log file path
- * @param {number} batchesPerDownloadSession - maximum IDs to return
- * @param {any} ee - emit `error` event if log file invalid
- * @param {function} callback - sign (err, batchSetIds array)
- */
-function readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, ee, callback) {
-  logfilesummary(log, function processSummary(err, summary) {
-    if (!summary.changesComplete) {
-      ee.emit('error', new error.BackupError(
-        'IncompleteChangesInLogFile',
-        'WARNING: Changes did not finish spooling'
-        ));
-    }
-    if (Object.keys(summary.batches).length === 0) {
-      return callback(null, []);
+    function process(done) {
+      logfilegetbatches(log, allBatchIds.splice(0, maxBatchFetch).map(Number), function(err, batches) {
+        processBatches(dbUrl, parallelism, log, batches, ee, startTime, total, function(err, newTotal) {
+          total = newTotal;
+          if (err) {
+            hasErrored = true;
+            done(err, total);
+          } else {
+            done(null, total);
+          }
+        });
+      });
     }
 
-    // batch IDs are the property names of summary.batches
-    var batchSetIds = getPropertyNames(summary.batches, batchesPerDownloadSession);
-    callback(null, batchSetIds);
+    function isComplete() {
+      return hasErrored || allBatchIds.length === 0;
+    }
+
+    function onComplete(err, total) {
+      if (err) {
+        ee.emit('error', err);
+      } else {
+        ee.emit('finished', {total: total});
+      }
+    }
+
+    async.doUntil(process, isComplete, onComplete);
   });
 }
 
 /**
- * Download a set of batches retrieved from a log file. When a download is
- * complete, add a line to the logfile indicating such.
+ * Return all uncompleted download batch IDs from the log file.
+ *
+ * @param {string} log - log file path
+ * @param {function} callback - called once complete with signature is (err,
+ * batchSetIds array)
+ */
+function readAllBatchIdsFromLogFile(log, callback) {
+  logfilesummary(log, function(err, summary) {
+    if (!summary.changesComplete) {
+      callback(new error.BackupError('IncompleteChangesInLogFile', 'WARNING: Changes did not finish spooling'));
+    } else {
+      callback(null, Object.keys(summary.batches));
+    }
+  });
+}
+
+/**
+ * Download a batch retrieved from a log file. When a download is complete, add
+ * a line to the logfile indicating such.
  *
  * @param {any} dbUrl - URL of database
  * @param {any} parallelism - number of concurrent requests to make
  * @param {any} log - log file to drive downloads from
  * @param {any} batches - batches to download
- * @param {any} ee - event emitter for progress. This funciton emits
- *  received and error events.
+ * @param {any} ee - event emitter for progress. This funciton emits received
+ *  and error events.
  * @param {any} start - time backup started, to report deltas
- * @param {any} grandtotal - count of documents downloaded prior to this set
- *  of batches
- * @param {any} callback - completion callback, (err, {total: number}).
+ * @param {any} total - count of documents downloaded
+ * @param {function} callback - called once complete with signature (err, total)
+ * where total is the number of documents downloaded
  */
-function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal, callback) {
-  const client = request.client(dbUrl, parallelism);
-  var total = grandtotal;
+function processBatches(dbUrl, parallelism, log, batches, ee, start, total, callback) {
+  var q = async.queue(function(batch, done) {
+    function doBulkGet(callback) {
+      var r = {
+        url: dbUrl + '/_bulk_get',
+        qs: { revs: true },
+        method: 'post',
+        body: {docs: batch.docs}
+      };
 
-  // queue to process the fetch requests in an orderly fashion using _bulk_get
-  var q = async.queue(function(payload, done) {
-    var output = [];
-    var thisBatch = payload.batch;
-    delete payload.batch;
+      client(r, function(err, res, data) {
+        if (err) {
+          callback(err);
+        } else if (res.statusCode !== 200) {
+          callback(new error.BackupError('BackupRetrieveError', `ERROR: Failed to get document batch ${batch.batch}, status code ${res.statusCode}`));
+        } else if (!data || !data.results) {
+          callback(new error.BackupError('BackupRetrieveError', `ERROR: Received invalid bulk get response for document batch ${batch.batch}`));
+        } else {
+          var output = [];
+          data.results.forEach(function(d) {
+            if (d.docs) {
+              d.docs.forEach(function(doc) {
+                if (doc.ok) {
+                  output.push(doc.ok);
+                }
+              });
+            }
+          });
+          callback(null, output);
+        }
+      });
+    }
 
     function logCompletedBatch(batch) {
       if (log) {
-        fs.appendFile(log, ':d batch' + thisBatch + '\n', done);
+        fs.appendFile(log, ':d batch' + batch + '\n', done);
       } else {
         done();
       }
     }
 
-    // do the /db/_bulk_get request
-    var r = {
-      url: dbUrl + '/_bulk_get',
-      qs: { revs: true }, // gets previous revision tokens too
-      method: 'post',
-      body: payload
-    };
-    client(r, function(err, res, data) {
-      if (!err && data && data.results) {
-        // create an output array with the docs returned
-        data.results.forEach(function(d) {
-          if (d.docs) {
-            d.docs.forEach(function(doc) {
-              if (doc.ok) {
-                output.push(doc.ok);
-              }
-            });
-          }
-        });
-        total += output.length;
-        var t = (new Date().getTime() - start) / 1000;
-        ee.emit('received', {length: output.length, time: t, total: total, data: output, batch: thisBatch}, q, logCompletedBatch);
-      } else {
+    async.retry(3, doBulkGet, function(err, results) {
+      if (err) {
         ee.emit('error', err);
         done();
+      } else {
+        var docCount = results.length;
+        total += docCount;
+
+        var data = {
+          length: docCount,
+          time: (new Date().getTime() - start) / 1000,
+          total: total,
+          data: results,
+          batch: batch.batch
+        };
+
+        ee.emit('received', data, q, logCompletedBatch);
       }
     });
   }, parallelism);
 
+  // add batches to work queue
   for (var i in batches) {
     q.push(batches[i]);
   }
 
-  q.drain = function() {
-    callback(null, {total: total});
-  };
-}
-
-/**
- * Returns first N properties on an object.
- *
- * @param {object} obj - object with properties
- * @param {number} count - number of properties to return
- */
-function getPropertyNames(obj, count) {
-  // decide which batch numbers to deal with
-  var batchestofetch = [];
-  var j = 0;
-  for (var i in obj) {
-    batchestofetch.push(parseInt(i));
-    j++;
-    if (j >= count) break;
-  }
-  return batchestofetch;
+  // callback with new total once complete
+  q.drain = function() { callback(null, total); };
 }

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -53,7 +53,7 @@ module.exports = function(dbUrl, log, bufferSize, callback) {
       if (c.error) {
         console.error('error', c);
       } else if (c.changes) {
-        var obj = {id: c.id};
+        var obj = {id: c.id, rev: c.changes[0].rev, deleted: c.deleted || false};
         buffer.push(obj);
         processBuffer(false);
       } else if (c.last_seq) {


### PR DESCRIPTION
# What
Check for the `/_bulk_get` endpoint. If it's missing then fetch document revisions individually.

## How
Check the bulk get endpoint exists using a GET `/_bulk_get` request.
 - On `405 Method Not Allowed`, proceed as normal.
 - On `404 Object Not Found`, fetch documents individually using the GET `/db/docid` endpoint with a selection of URL parameters to ensure all live and non-live revisions are captured in the backup.

## Testing
Includes additional CI test for unsupported `/_bulk_get`.

## Issues
Fixes #107.
