### PR TITLE
115 validate writer requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
   parallelism.
 - [IMPROVED] Better error handling in couchrestore when remote database
   cannot be written to.
+- [IMPROVED] Validate HTTP writer responses when restoring a database.
 - [FIXED] An issue where the process could exit before the backup content was
   completely flushed to the destination stream.
 - [FIXED] An issue where back pressure on the output stream was ignored

--- a/includes/error.js
+++ b/includes/error.js
@@ -22,7 +22,8 @@ const codes = {
   'NoLogFileName': 20,
   'LogDoesNotExist': 21,
   'IncompleteChangesInLogFile': 22,
-  'SpoolChangesError': 30
+  'SpoolChangesError': 30,
+  'HTTPFatalError': 40
 };
 
 module.exports = {

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -54,15 +54,13 @@ function exists(dbUrl, callback) {
       return;
     }
     if (res) {
-      if (res.statusCode === 200) {
-        callback(null, true);
-      } else if (res.statusCode === 404) {
-        callback(null, false);
-      } else {
-        // generic error code (for now, maybe map HTTP status codes to explanations?)
-        var e = new Error(`HEAD ${dbUrl} returned error code ${res.statusCode}`);
-        callback(e, false);
-      }
+      request.checkResponseAndCallbackFatalError(res, function(err) {
+        if (err) {
+          callback(err, false);
+        } else {
+          callback(null, true);
+        }
+      });
     }
   });
 }

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -36,7 +36,7 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
     }
     var r = {
       url: dbUrl + '/_all_docs',
-      method: 'get',
+      method: 'GET',
       qs: opts
     };
     client(r, function(err, res, data) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "cloudant": "^1.7.1",
     "uuid": "^3.0.1",
     "tail": "^1.2.1",
-    "rewire": "^2.4.20"
+    "rewire": "^2.4.20",
+    "nock": "^9.0.13"
   },
   "scripts": {
     "test": "eslint --ignore-path .gitignore . && mocha --grep \"#unit\""

--- a/test/request.js
+++ b/test/request.js
@@ -1,0 +1,83 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+'use strict';
+
+var assert = require('assert');
+var nock = require('nock');
+var request = require('../includes/request.js');
+
+describe('#unit Check request response', function() {
+  const url = 'http://localhost:5984';
+  const client = request.client(url, 1);
+
+  it('should not callback with error for 200 response', function(done) {
+    var couch = nock(url)
+        .get('/good')
+        .reply(200, {ok: true});
+
+    client({url: url + '/good', method: 'GET'}, function(err, res, data) {
+      request.checkResponseAndCallbackError(res, function(err) {
+        assert.equal(err, null);
+        assert.ok(couch.isDone());
+        done();
+      });
+    });
+  });
+
+  it('should not callback with fatal error for 200 response', function(done) {
+    var couch = nock(url)
+        .get('/good')
+        .reply(200, {ok: true});
+
+    client({url: url + '/good', method: 'GET'}, function(err, res, data) {
+      request.checkResponseAndCallbackFatalError(res, function(err) {
+        assert.equal(err, null);
+        assert.ok(couch.isDone());
+        done();
+      });
+    });
+  });
+
+  it('should callback with error for 500 response', function(done) {
+    var couch = nock(url)
+        .get('/bad')
+        .reply(500, {error: 'foo', reason: 'bar'});
+
+    client({url: url + '/bad', method: 'GET'}, function(err, res, data) {
+      request.checkResponseAndCallbackError(res, function(err) {
+        assert.equal(err.name, 'HTTPError');
+        assert.equal(err.message, `500 : GET ${url}/bad - Error: foo, Reason: bar`);
+        assert.ok(couch.isDone());
+        done();
+      });
+    });
+  });
+
+  it('should callback with fatal error for 500 response', function(done) {
+    var couch = nock(url)
+        .get('/bad')
+        .reply(500, {error: 'foo', reason: 'bar'});
+
+    client({url: url + '/bad', method: 'GET'}, function(err, res, data) {
+      request.checkResponseAndCallbackFatalError(res, function(err) {
+        assert.equal(err.name, 'HTTPFatalError');
+        assert.equal(err.message, `500 : GET ${url}/bad - Error: foo, Reason: bar`);
+        assert.ok(couch.isDone());
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What
Use newly added `request.isOK` & `request.isFatal` HTTP status code validators anywhere we validate HTTP response codes.

## How
Add HTTP status code validators to `request.js`. 

- `request.isFatal` will return a new `HTTPFatalError` error on failure that will terminate the CLI.
- `request.isOK` will return a new `HTTPError` error on failure that logs an error with the event emitter.

## Issues
Fixes #115 and is closely related to #32.