### PR TITLE
107 fetch docs if no bulk get

### DIFF
--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -57,7 +57,7 @@ return couchbackup.backup(
   opts,
   error.terminationCallback
 ).on('written', function(obj) {
-  debug('written', obj.batch, ' docs: ', obj.total, 'Time', obj.time);
+  debug('written batch:', obj.batch, 'total docs written: ', obj.total, 'time:', obj.time);
 }).on('error', function(e) {
   debug('ERROR', e);
 }).on('finished', function(obj) {

--- a/includes/error.js
+++ b/includes/error.js
@@ -22,7 +22,8 @@ const codes = {
   'NoLogFileName': 20,
   'LogDoesNotExist': 21,
   'IncompleteChangesInLogFile': 22,
-  'SpoolChangesError': 30
+  'SpoolChangesError': 30,
+  'BulkGetCheckFailure': 40
 };
 
 module.exports = {

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -53,7 +53,7 @@ module.exports = function(dbUrl, log, bufferSize, callback) {
       if (c.error) {
         console.error('error', c);
       } else if (c.changes) {
-        var obj = {id: c.id};
+        var obj = {id: c.id, rev: c.changes[0].rev, deleted: c.deleted || false};
         buffer.push(obj);
         processBuffer(false);
       } else if (c.last_seq) {


### PR DESCRIPTION
# What
Check for the `/_bulk_get` endpoint. If it's missing then fetch document revisions individually.

## How
Check the bulk get endpoint exists using a GET `/_bulk_get` request.
 - On `405 Method Not Allowed`, proceed as normal.
 - On `404 Object Not Found`, fetch documents individually using the GET `/db/docid` endpoint with a selection of URL parameters to ensure all live and non-live revisions are captured in the backup.

## Testing
Includes additional CI test for unsupported `/_bulk_get`.

## Issues
Fixes #107.