### PR TITLE
Remove stderr logging from library

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ The `restore` function returns an event emitter. You can subscribe to:
 * `finished` - emitted once when all documents are restored.
 * `error` - emitted when something goes wrong for a single batch.
 
+The backup file (or `srcStream`) contains lists comprising of document
+revisions, where each list is separated by a newline. The list length is
+dictated by the `bufferSize` parameter used during the backup.
+
+It's possible a list could be corrupt due to failures in the backup process. A
+`BackupFileJsonError` is emitted for each corrupt list found. _These can only be
+ignored if the backup that generated the stream did complete successfully_. This
+ensures that corrupt lists also have a valid counterpart within the stream.
 
 Restore data from a stream:
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ the backup completes or fails.
 
 The `backup` function returns an event emitter. You can subscribe to:
 
+* `changes` - when a batch of changes has been written to log stream.
 * `written` - when a batch of documents has been written to backup stream.
 * `finished` - emitted once when all documents are backed up.
 * `error` - emitted when something goes wrong for a single batch.

--- a/app.js
+++ b/app.js
@@ -123,7 +123,9 @@ module.exports = {
     }
 
     backup(srcUrl, opts.bufferSize, opts.parallelism, opts.log, opts.resume)
-      .on('received', function(obj, q, logCompletedBatch) {
+      .on('changes', function(batch) {
+        ee.emit('changes', batch);
+      }).on('received', function(obj, q, logCompletedBatch) {
         debug(' backed up batch', obj.batch, ' docs: ', obj.total, 'Time', obj.time);
         // Callback to emit the written event when the content is flushed
         function writeFlushed() {
@@ -200,6 +202,7 @@ module.exports = {
       opts.bufferSize,
       opts.parallelism,
       srcStream,
+      ee,
       function(err, writer) {
         if (err) {
           callback(err, null);

--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -51,15 +51,19 @@ if (program.output) {
   ws = fs.createWriteStream(null, { fd: fd });
 }
 
+debug('Fetching all database changes...');
+
 return couchbackup.backup(
   databaseUrl,
   ws,
   opts,
   error.terminationCallback
-).on('written', function(obj) {
-  debug('written', obj.batch, ' docs: ', obj.total, 'Time', obj.time);
+).on('changes', function(batch) {
+  debug('Total batches received:', batch + 1);
+}).on('written', function(obj) {
+  debug('Written batch ID:', obj.batch, 'Total document revisions written:', obj.total, 'Time:', obj.time);
 }).on('error', function(e) {
   debug('ERROR', e);
 }).on('finished', function(obj) {
-  debug('finished', obj);
+  debug('Finished - Total document revisions written:', obj.total);
 });

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -53,7 +53,7 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
       downloadRemainingBatches(log, dbUrl, ee, start, batchesPerDownloadSession, parallelism);
     } else {
       // create new log file and process
-      spoolchanges(dbUrl, log, blocksize, function(err) {
+      spoolchanges(dbUrl, log, blocksize, ee, function(err) {
         if (err) {
           ee.emit('error', err);
         } else {

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -15,7 +15,7 @@
 
 const request = require('./request.js');
 
-module.exports = function(dbUrl, buffersize, parallelism, readstream, callback) {
+module.exports = function(dbUrl, buffersize, parallelism, readstream, ee, callback) {
   exists(dbUrl, function(err, exists) {
     if (err) {
       callback(err, null);
@@ -27,7 +27,7 @@ module.exports = function(dbUrl, buffersize, parallelism, readstream, callback) 
     }
 
     var liner = require('../includes/liner.js');
-    var writer = require('../includes/writer.js')(dbUrl, buffersize, parallelism);
+    var writer = require('../includes/writer.js')(dbUrl, buffersize, parallelism, ee);
 
     // pipe the input to the output, via transformation functions
     readstream.pipe(liner())        // transform the input stream into per-line

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -248,6 +248,8 @@ function testRestore(params, inputStream, databaseName, callback) {
         console.log(data);
         callback();
       }
+    }).on('error', function(err) {
+      console.error(`Caught non-fatal error: ${err}`);
     });
   } else {
     // Note use spawn not fork for stdio options not supported with fork in Node 4.x
@@ -342,7 +344,7 @@ function assertResumedBackup(params, resumedBackup, restoreCallback) {
     // For the CLI case we need to see the output because we don't have
     // the finished event.
     const listener = function(data) {
-      let matches = data.toString().match(/.*finished { total: (\d+) }.*/);
+      let matches = data.toString().match(/.*Finished - Total document revisions written: (\d+).*/);
       if (matches !== null) {
         assertWrittenFewerThan(matches[1], params.exclusiveMaxExpected, restoreCallback);
         resumedBackup.stderr.removeListener('data', listener);


### PR DESCRIPTION
## What
Remove stderr logging from library.

## How
Ensure all errors are passed via the event emitter to the listening client rather than being printed directly to stderr.

## Issues
See #32.
