### PR TITLE
128 handle fatal errors in shallow backup

### DIFF
--- a/test/fixtures/animaldb_all_docs_1.json
+++ b/test/fixtures/animaldb_all_docs_1.json
@@ -1,0 +1,100 @@
+{
+  "total_rows": 11,
+  "offset": 0,
+  "rows": [
+    {
+      "id": "_design/views101",
+      "key": "_design/views101",
+      "value": {
+        "rev": "1-af8f4cfc28e685f171f52fcdde460be2"
+      },
+      "doc": {
+        "_id": "_design/views101",
+        "_rev": "1-af8f4cfc28e685f171f52fcdde460be2",
+        "indexes": {
+          "animals": {
+            "index": "function(doc){\n  index(\"default\", doc._id);\n  if(doc.min_length){\n    index(\"min_length\", doc.min_length, {\"store\": \"yes\"});\n  }\n  if(doc.diet){\n    index(\"diet\", doc.diet, {\"store\": \"yes\"});\n  }\n  if (doc.latin_name){\n    index(\"latin_name\", doc.latin_name, {\"store\": \"yes\"});\n  }\n  if (doc['class']){\n    index(\"class\", doc['class'], {\"store\": \"yes\"});\n  }\n}"
+          }
+        },
+        "views": {
+          "latin_name_jssum": {
+            "map": "function(doc) {\n  if(doc.latin_name){\n    emit(doc.latin_name, doc.latin_name.length);\n  }\n}",
+            "reduce": "function (key, values, rereduce){\n  return sum(values);\n}"
+          },
+          "latin_name": {
+            "map": "function(doc) {\n  if(doc.latin_name){\n    emit(doc.latin_name, doc.latin_name.length);\n  }\n}"
+          },
+          "diet_sum": {
+            "map": "function(doc) {\n  if(doc.diet){\n    emit(doc.diet, 1);\n  }\n}",
+            "reduce": "_sum"
+          },
+          "diet_count": {
+            "map": "function(doc) {\n  if(doc.diet && doc.latin_name){\n    emit(doc.diet, doc.latin_name);\n  }\n}",
+            "reduce": "_count"
+          },
+          "complex_count": {
+            "map": "function(doc){\n  if(doc.class && doc.diet){\n    emit([doc.class, doc.diet], 1);\n  }\n}",
+            "reduce": "_count"
+          },
+          "diet": {
+            "map": "function(doc) {\n  if(doc.diet){\n    emit(doc.diet, 1);\n  }\n}"
+          },
+          "complex_latin_name_count": {
+            "map": "function(doc){\n  if(doc.latin_name){\n    emit([doc.class, doc.diet, doc.latin_name], doc.latin_name.length)\n  }\n}",
+            "reduce": "_count"
+          },
+          "diet_jscount": {
+            "map": "function(doc) {\n  if(doc.diet){\n    emit(doc.diet, 1);\n  }\n}",
+            "reduce": "function (key, values, rereduce){\n  return values.length;\n}"
+          },
+          "latin_name_count": {
+            "map": "function(doc) {\n  if(doc.latin_name){\n    emit(doc.latin_name, doc.latin_name.length);\n  }\n}",
+            "reduce": "_count"
+          },
+          "latin_name_sum": {
+            "map": "function(doc) {\n  if(doc.latin_name){\n    emit(doc.latin_name, doc.latin_name.length);\n  }\n}",
+            "reduce": "_sum"
+          }
+        }
+      }
+    },
+    {
+      "id": "aardvark",
+      "key": "aardvark",
+      "value": {
+        "rev": "1-be3290452e032dc34de9c0e9e8c1739e"
+      },
+      "doc": {
+        "_id": "aardvark",
+        "_rev": "1-be3290452e032dc34de9c0e9e8c1739e",
+        "min_length": 1,
+        "min_weight": 40,
+        "latin_name": "Orycteropus afer",
+        "diet": "omnivore",
+        "max_length": 2.2,
+        "wiki_page": "http://en.wikipedia.org/wiki/Aardvark",
+        "class": "mammal",
+        "max_weight": 65
+      }
+    },
+    {
+      "id": "badger",
+      "key": "badger",
+      "value": {
+        "rev": "1-d4e5759e694a9659d1acaa98040e52fd"
+      },
+      "doc": {
+        "_id": "badger",
+        "_rev": "1-d4e5759e694a9659d1acaa98040e52fd",
+        "min_length": 0.6,
+        "min_weight": 7,
+        "latin_name": "Meles meles",
+        "diet": "omnivore",
+        "max_length": 0.9,
+        "wiki_page": "http://en.wikipedia.org/wiki/Badger",
+        "class": "mammal",
+        "max_weight": 30
+      }
+    }
+  ]
+}

--- a/test/fixtures/animaldb_all_docs_2.json
+++ b/test/fixtures/animaldb_all_docs_2.json
@@ -1,0 +1,59 @@
+{
+  "total_rows": 11,
+  "offset": 0,
+  "rows": [
+    {
+      "id": "elephant",
+      "key": "elephant",
+      "value": {
+        "rev": "1-4698ce7bbcdfb6644c1719e205a4130d"
+      },
+      "doc": {
+        "_id": "elephant",
+        "_rev": "1-4698ce7bbcdfb6644c1719e205a4130d",
+        "min_length": 3.2,
+        "min_weight": 4700,
+        "diet": "herbivore",
+        "max_length": 4,
+        "wiki_page": "http://en.wikipedia.org/wiki/African_elephant",
+        "class": "mammal",
+        "max_weight": 6050
+      }
+    },
+    {
+      "id": "giraffe",
+      "key": "giraffe",
+      "value": {
+        "rev": "1-5874d944abf1261c2a244a92b14c2f18"
+      },
+      "doc": {
+        "_id": "giraffe",
+        "_rev": "1-5874d944abf1261c2a244a92b14c2f18",
+        "min_length": 5,
+        "min_weight": 830,
+        "diet": "herbivore",
+        "max_length": 6,
+        "wiki_page": "http://en.wikipedia.org/wiki/Giraffe",
+        "class": "mammal",
+        "max_weight": 1600
+      }
+    },
+    {
+      "id": "kookaburra",
+      "key": "kookaburra",
+      "value": {
+        "rev": "1-0266ecfcdf2f0be7cbfa696dc7f0088e"
+      },
+      "doc": {
+        "_id": "kookaburra",
+        "_rev": "1-0266ecfcdf2f0be7cbfa696dc7f0088e",
+        "min_length": 0.28,
+        "latin_name": "Dacelo novaeguineae",
+        "diet": "carnivore",
+        "max_length": 0.42,
+        "wiki_page": "http://en.wikipedia.org/wiki/Kookaburra",
+        "class": "bird"
+      }
+    }
+  ]
+}

--- a/test/fixtures/animaldb_all_docs_3.json
+++ b/test/fixtures/animaldb_all_docs_3.json
@@ -1,0 +1,62 @@
+{
+  "total_rows": 11,
+  "offset": 0,
+  "rows": [
+    {
+      "id": "llama",
+      "key": "llama",
+      "value": {
+        "rev": "1-342255201b0d698e70f9828b7002e30a"
+      },
+      "doc": {
+        "_id": "llama",
+        "_rev": "1-342255201b0d698e70f9828b7002e30a",
+        "min_length": 1.7,
+        "min_weight": 130,
+        "latin_name": "Lama glama",
+        "diet": "herbivore",
+        "max_length": 1.8,
+        "wiki_page": "http://en.wikipedia.org/wiki/Llama",
+        "class": "mammal",
+        "max_weight": 200
+      }
+    },
+    {
+      "id": "panda",
+      "key": "panda",
+      "value": {
+        "rev": "1-45e8c0010dd80b7e60d3a50f5bcf348f"
+      },
+      "doc": {
+        "_id": "panda",
+        "_rev": "1-45e8c0010dd80b7e60d3a50f5bcf348f",
+        "min_length": 1.2,
+        "min_weight": 75,
+        "diet": "carnivore",
+        "max_length": 1.8,
+        "wiki_page": "http://en.wikipedia.org/wiki/Panda",
+        "class": "mammal",
+        "max_weight": 115
+      }
+    },
+    {
+      "id": "snipe",
+      "key": "snipe",
+      "value": {
+        "rev": "1-cb497ff296134b6e8c311963d1d41ea6"
+      },
+      "doc": {
+        "_id": "snipe",
+        "_rev": "1-cb497ff296134b6e8c311963d1d41ea6",
+        "min_length": 0.25,
+        "min_weight": 0.08,
+        "latin_name": "Gallinago gallinago",
+        "diet": "omnivore",
+        "max_length": 0.27,
+        "wiki_page": "http://en.wikipedia.org/wiki/Common_Snipe",
+        "class": "bird",
+        "max_weight": 0.14
+      }
+    }
+  ]
+}

--- a/test/fixtures/animaldb_all_docs_4.json
+++ b/test/fixtures/animaldb_all_docs_4.json
@@ -1,0 +1,43 @@
+{
+  "total_rows": 11,
+  "offset": 0,
+  "rows": [
+    {
+      "id": "snipe",
+      "key": "snipe",
+      "value": {
+        "rev": "1-cb497ff296134b6e8c311963d1d41ea6"
+      },
+      "doc": {
+        "_id": "snipe",
+        "_rev": "1-cb497ff296134b6e8c311963d1d41ea6",
+        "min_length": 0.25,
+        "min_weight": 0.08,
+        "latin_name": "Gallinago gallinago",
+        "diet": "omnivore",
+        "max_length": 0.27,
+        "wiki_page": "http://en.wikipedia.org/wiki/Common_Snipe",
+        "class": "bird",
+        "max_weight": 0.14
+      }
+    },
+    {
+      "id": "zebra",
+      "key": "zebra",
+      "value": {
+        "rev": "1-154a9574f7aa96df26a6752fc10b7759"
+      },
+      "doc": {
+        "_id": "zebra",
+        "_rev": "1-154a9574f7aa96df26a6752fc10b7759",
+        "min_length": 2,
+        "min_weight": 175,
+        "diet": "herbivore",
+        "max_length": 2.5,
+        "wiki_page": "http://en.wikipedia.org/wiki/Plains_zebra",
+        "class": "mammal",
+        "max_weight": 387
+      }
+    }
+  ]
+}

--- a/test/shallowbackup.js
+++ b/test/shallowbackup.js
@@ -1,0 +1,144 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it beforeEach */
+'use strict';
+
+const assert = require('assert');
+const backup = require('../includes/shallowbackup.js');
+const fs = require('fs');
+const nock = require('nock');
+
+describe('#unit Perform backup using shallow backup', function() {
+  const dbUrl = 'http://localhost:5984/animaldb';
+
+  beforeEach('Reset nocks', function() {
+    nock.cleanAll();
+  });
+
+  it('should perform a shallow backup', function(done) {
+    var couch = nock(dbUrl)
+      // batch 1
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_1.json', 'utf8')))
+      // batch 2
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"badger\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_2.json', 'utf8')))
+      // batch 3
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"kookaburra\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_3.json', 'utf8')))
+      // batch 4
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"snipe\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_4.json', 'utf8')));
+
+    backup(dbUrl, 3, 1, null, null)
+      .on('error', function(err) {
+        assert.fail(err);
+      })
+      .on('received', function(data) {
+        if (data.batch === 3) {
+          assert.equal(data.length, 2); // smaller last batch
+        } else {
+          assert.equal(data.length, 3);
+        }
+      })
+      .on('finished', function(data) {
+        assert.equal(data.total, 11);
+        couch.isDone();
+        done();
+      });
+  });
+
+  it('should perform a shallow backup with transient error', function(done) {
+    var couch = nock(dbUrl)
+      // batch 1
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_1.json', 'utf8')))
+      // batch 2
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"badger\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_2.json', 'utf8')))
+      // batch 3 - transient error
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"kookaburra\\u0000"'})
+      .reply(500, {error: 'Internal Server Error'})
+      // batch 3 - retry
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"kookaburra\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_3.json', 'utf8')))
+      // batch 4
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"snipe\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_4.json', 'utf8')));
+
+    var errCount = 0;
+
+    backup(dbUrl, 3, 1, null, null)
+      .on('error', function(err) {
+        errCount++;
+        assert.equal(err.name, 'HTTPError');
+      })
+      .on('received', function(data) {
+        if (data.batch === 3) {
+          assert.equal(data.length, 2); // smaller last batch
+        } else {
+          assert.equal(data.length, 3);
+        }
+      })
+      .on('finished', function(data) {
+        assert.equal(data.total, 11);
+        couch.isDone();
+        assert.equal(errCount, 1);
+        done();
+      });
+  });
+
+  it('should fail to perform a shallow backup on fatal error', function(done) {
+    var couch = nock(dbUrl)
+      // batch 1
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_1.json', 'utf8')))
+      // batch 2
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"badger\\u0000"'})
+      .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_2.json', 'utf8')))
+      // batch 3 - fatal error
+      .get('/_all_docs')
+      .query({limit: 3, include_docs: true, startkey: '"kookaburra\\u0000"'})
+      .reply(401, {error: 'Unauthorized'});
+
+    var errCount = 0;
+
+    backup(dbUrl, 3, 1, null, null)
+      .on('error', function(err) {
+        errCount++;
+        assert.equal(err.name, 'Unauthorized');
+      })
+      .on('received', function(data) {
+        assert.equal(data.length, 3);
+      })
+      .on('finished', function(data) {
+        assert.equal(data.total, 6);
+        couch.isDone();
+        assert.equal(errCount, 1);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
## What
Handle fatal errors in shallow backup.

## How
Use `request.checkResponseAndCallbackError` to check `/_all_docs` responses. If fatal, terminate the backup and emit an error.

## Testing
Includes additional unit tests.

The commented test requires https://github.com/cloudant/couchbackup/tree/22-permanent-errors.

## Issues
Fixes #128.