### PR TITLE
22 restore multiple fatal

### DIFF
--- a/includes/writer.js
+++ b/includes/writer.js
@@ -59,9 +59,10 @@ module.exports = function(couchDbUrl, bufferSize, parallelism, ee) {
     });
   }, parallelism);
 
+  var didError = false;
+
   // write the contents of the buffer to CouchDB in blocks of bufferSize
   function processBuffer(flush, callback) {
-    var didError = false;
     function taskCallback(err) {
       if (err && !didError) {
         debug(`Queue task failed with error ${err.name}`);

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -41,7 +41,7 @@ module.exports = function(couchDbUrl, bufferSize, parallelism, ee) {
       body: payload
     };
 
-    const response = client(r, function(err, res, data) {
+    client(r, function(err, res, data) {
       if (!err) {
         // No request error, check the response for an error
         request.checkResponseAndCallbackFatalError(res, function(responseError) {
@@ -50,16 +50,7 @@ module.exports = function(couchDbUrl, bufferSize, parallelism, ee) {
       }
       if (err) {
         debug(`Error writing docs ${err.name} ${err.message}`);
-        if (!err.isTransient) {
-          debug(`Fatal error: ${err.name}`);
-          response.abort();
-          q.kill();
-          cb(err);
-        } else {
-          debug(`Emitting non-fatal error: ${err.name}`);
-          writer.emit('error', err);
-          cb();
-        }
+        cb(err);
       } else {
         written += payload.docs.length;
         writer.emit('restored', {documents: payload.docs.length, total: written});
@@ -74,8 +65,11 @@ module.exports = function(couchDbUrl, bufferSize, parallelism, ee) {
     function taskCallback(err) {
       if (err && !didError) {
         debug(`Queue task failed with error ${err.name}`);
-        didError = true;
-        callback(err);
+        if (!err.isTransient) {
+          didError = true;
+          q.kill();
+        }
+        writer.emit('error', err);
       }
     }
 

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -249,7 +249,7 @@ function testRestore(params, inputStream, databaseName, callback) {
   }
 
   if (params.useApi) {
-    app.restore(restoreStream, dbUrl(process.env.COUCH_URL, databaseName), null, function(err, data) {
+    app.restore(restoreStream, dbUrl(process.env.COUCH_URL, databaseName), params.opts, function(err, data) {
       if (err) {
         if (params.expectedRestoreError) {
           try {
@@ -269,8 +269,17 @@ function testRestore(params, inputStream, databaseName, callback) {
       console.error(`Caught non-fatal error: ${err}`);
     });
   } else {
+    // Set up default args
+    const args = ['./bin/couchrestore.bin.js', '--db', databaseName];
+    if (params.opts) {
+      if (params.opts.bufferSize) {
+        args.push('--buffer-size');
+        args.push(params.opts.bufferSize);
+      }
+    }
+
     // Note use spawn not fork for stdio options not supported with fork in Node 4.x
-    const restore = spawn('node', ['./bin/couchrestore.bin.js', '--db', databaseName], {'stdio': ['pipe', 'inherit', 'inherit']});
+    const restore = spawn('node', args, {'stdio': ['pipe', 'inherit', 'inherit']});
     // Pipe to write the readable inputStream into stdin
     restoreStream.pipe(restore.stdin);
     restore.on('close', function(code) {

--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -188,6 +188,15 @@ function restoreHttpError(opts, errorName, errorCode, done) {
         n.post('/fakenockdb/_bulk_docs').reply(400, {error: 'bad_request', reason: 'testing bad response'});
         restoreHttpError(params, 'HTTPFatalError', 40, done);
       });
+
+      it('should terminate on multiple _bulk_docs HTTPFatalError', function(done) {
+        const p = u.p(params, {opts: {bufferSize: 1}});
+        // Simulate the DB exists
+        const n = nock(url).head('/fakenockdb').reply(200, {ok: true});
+        // Simulate a 500 trying to write docs, 5 times because of parallelism
+        n.post('/fakenockdb/_bulk_docs').times(5).reply(400, {error: 'bad_request', reason: 'testing bad response'});
+        restoreHttpError(p, 'HTTPFatalError', 40, done);
+      });
     });
   });
 });


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

What was changed, e.g.
>Added support for incremental backup mode

## How

After #133 merged there were some problems with multiple callbacks for multiple queue tasks failing with HTTP errors on restore.

Used the event emitter to emit `error` instead of calling back with an error to the `_transform` method's `done` callback, because that would already get called when the docs were pushed to the queue, and then get called again if an error happened.

Note `CHANGES` already updated under #133 

## Testing

Added new test `should terminate on multiple _bulk_docs HTTPFatalError` that uses a `bufferSize: 1` to ensure multiple queue tasks will fail to cover this branch.

## Issues

Additional impact from #22 
