### PR TITLE
135 handle spool changes errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,31 +55,31 @@ function isSafePositiveInteger(x) {
  */
 function validateArgs(url, opts, cb) {
   if (typeof url !== 'string') {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid URL, must be type string'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid URL, must be type string'), null);
     return;
   }
   if (opts && typeof opts.bufferSize !== 'undefined' && !isSafePositiveInteger(opts.bufferSize)) {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
     return;
   }
   if (opts && typeof opts.log !== 'undefined' && typeof opts.log !== 'string') {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid log option, must be type string'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid log option, must be type string'), null);
     return;
   }
   if (opts && typeof opts.mode !== 'undefined' && ['full', 'shallow'].indexOf(opts.mode) === -1) {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid mode option, must be either "full" or "shallow"'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid mode option, must be either "full" or "shallow"'), null);
     return;
   }
   if (opts && typeof opts.output !== 'undefined' && typeof opts.output !== 'string') {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid output option, must be type string'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid output option, must be type string'), null);
     return;
   }
   if (opts && typeof opts.parallelism !== 'undefined' && !isSafePositiveInteger(opts.parallelism)) {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
     return;
   }
   if (opts && typeof opts.resume !== 'undefined' && typeof opts.resume !== 'boolean') {
-    cb(new error.BackupError('InvalidOption', 'ERROR: Invalid resume option, must be type boolean'), null);
+    cb(new error.BackupError('InvalidOption', 'Invalid resume option, must be type boolean'), null);
     return;
   }
   if (opts && opts.resume) {

--- a/app.js
+++ b/app.js
@@ -177,7 +177,7 @@ module.exports = {
       // For errors we expect, may or may not be fatal
       .on('error', function(err) {
         debug('Error ' + JSON.stringify(err));
-        if (err.isFatal) {
+        if (!err.isTransient) {
           // These are fatal errors
           // We only want to callback once for a fatal error
           // even though other errors may be received,
@@ -248,7 +248,7 @@ module.exports = {
           // For errors we expect, may or may not be fatal
           .on('error', function(err) {
             debug('Error ' + JSON.stringify(err));
-            if (err.isFatal) {
+            if (!err.isTransient) {
               // These are fatal errors
               // We only want to callback once for a fatal error
               // even though other errors may be received,

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -86,7 +86,7 @@ function validateBulkGetSupport(dbUrl, callback) {
     request.checkResponseAndCallbackError(res, callback, function(res) {
       switch (res.statusCode) {
         case 404:
-          return new error.BackupError('BulkGetError', 'ERROR: Database does not support /_bulk_get endpoint');
+          return new error.BackupError('BulkGetError', 'Database does not support /_bulk_get endpoint');
         case 405:
           // => supports /_bulk_get endpoint
           return;

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -133,7 +133,7 @@ function downloadRemainingBatches(log, dbUrl, ee, startTime, batchesPerDownloadS
     readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, function(err, batchSetIds) {
       if (err) {
         ee.emit('error', err);
-        if (err.isFatal) {
+        if (!err.isTransient) {
           // Stop processing changes file for fatal errors
           noRemainingBatches = true;
         }
@@ -228,7 +228,7 @@ function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal
       } else {
         request.checkResponseAndCallbackError(res, function(err) {
           if (err) {
-            if (err.isFatal) {
+            if (!err.isTransient) {
               // Kill the queue for fatal errors
               q.kill();
             }

--- a/includes/error.js
+++ b/includes/error.js
@@ -70,7 +70,7 @@ module.exports = {
   terminationCallback: function terminationCallback(err, data) {
     if (err) {
       process.on('uncaughtException', function(err) {
-        console.error(err.message);
+        console.error(`ERROR: ${err.message}`);
         process.exitCode = codes[err.name] || 1;
       });
       throw err;

--- a/includes/error.js
+++ b/includes/error.js
@@ -32,7 +32,7 @@ class BackupError extends Error {
   constructor(name, message) {
     super(message);
     this.name = name;
-    this.isFatal = codes[name] !== undefined || false;
+    this.isTransient = codes[name] === undefined;
   }
 }
 

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -70,6 +70,11 @@ module.exports = function(dbUrl, log, bufferSize, ee, callback) {
   var c = client(r);
   c.end();
 
+  c.on('error', function(err) {
+    c.abort();
+    callback(new error.BackupError('SpoolChangesError', `ERROR: Failed changes request - ${err.message}`));
+  });
+
   c.on('response', function(resp) {
     request.checkResponseAndCallbackFatalError(resp, function(err) {
       if (err) {

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -72,7 +72,7 @@ module.exports = function(dbUrl, log, bufferSize, ee, callback) {
 
   c.on('error', function(err) {
     c.abort();
-    callback(new error.BackupError('SpoolChangesError', `ERROR: Failed changes request - ${err.message}`));
+    callback(new error.BackupError('SpoolChangesError', `Failed changes request - ${err.message}`));
   });
 
   c.on('response', function(resp) {
@@ -88,7 +88,7 @@ module.exports = function(dbUrl, log, bufferSize, ee, callback) {
             processBuffer(true);
             if (!lastSeq) {
               logStream.end();
-              callback(new error.BackupError('SpoolChangesError', `ERROR: Changes request terminated before last_seq was sent`));
+              callback(new error.BackupError('SpoolChangesError', `Changes request terminated before last_seq was sent`));
             } else {
               logStream.end(':changes_complete ' + lastSeq + '\n', 'utf8', callback);
             }

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -85,7 +85,15 @@ module.exports = function(dbUrl, log, bufferSize, ee, callback) {
       } else {
         resp
           .pipe(liner())
+          .on('error', function(err) {
+            c.abort();
+            callback(err);
+          })
           .pipe(change(onChange))
+          .on('error', function(err) {
+            c.abort();
+            callback(err);
+          })
           .on('finish', function() {
             processBuffer(true);
             if (!lastSeq) {

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -50,7 +50,7 @@ module.exports = function(couchDbUrl, bufferSize, parallelism, ee) {
       }
       if (err) {
         debug(`Error writing docs ${err.name} ${err.message}`);
-        if (err.isFatal) {
+        if (!err.isTransient) {
           debug(`Fatal error: ${err.name}`);
           response.abort();
           q.kill();

--- a/test/app.js
+++ b/test/app.js
@@ -25,58 +25,58 @@ describe('#unit Validate arguments', function() {
   const goodUrl = 'http://localhost:5984/db';
 
   it('returns error for invalid URL type', function() {
-    validateArgs(true, {}, (err, data) => assert.equal(err.message, 'ERROR: Invalid URL, must be type string'));
+    validateArgs(true, {}, (err, data) => assert.equal(err.message, 'Invalid URL, must be type string'));
   });
   it('returns no error for valid URL type', function() {
     validateArgs(goodUrl, {}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid buffer size type', function() {
-    validateArgs(goodUrl, {bufferSize: '123'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {bufferSize: '123'}, (err, data) => assert.equal(err.message, 'Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns error for zero buffer size', function() {
-    validateArgs(goodUrl, {bufferSize: 0}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {bufferSize: 0}, (err, data) => assert.equal(err.message, 'Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns error for float buffer size', function() {
-    validateArgs(goodUrl, {bufferSize: 1.23}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {bufferSize: 1.23}, (err, data) => assert.equal(err.message, 'Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns no error for valid buffer size type', function() {
     validateArgs(goodUrl, {bufferSize: 123}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid log type', function() {
-    validateArgs(goodUrl, {log: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid log option, must be type string'));
+    validateArgs(goodUrl, {log: true}, (err, data) => assert.equal(err.message, 'Invalid log option, must be type string'));
   });
   it('returns no error for valid log type', function() {
     validateArgs(goodUrl, {log: 'log.txt'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid mode type', function() {
-    validateArgs(goodUrl, {mode: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid mode option, must be either "full" or "shallow"'));
+    validateArgs(goodUrl, {mode: true}, (err, data) => assert.equal(err.message, 'Invalid mode option, must be either "full" or "shallow"'));
   });
   it('returns error for invalid mode string', function() {
-    validateArgs(goodUrl, {mode: 'foobar'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid mode option, must be either "full" or "shallow"'));
+    validateArgs(goodUrl, {mode: 'foobar'}, (err, data) => assert.equal(err.message, 'Invalid mode option, must be either "full" or "shallow"'));
   });
   it('returns no error for valid mode type', function() {
     validateArgs(goodUrl, {mode: 'full'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid output type', function() {
-    validateArgs(goodUrl, {output: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid output option, must be type string'));
+    validateArgs(goodUrl, {output: true}, (err, data) => assert.equal(err.message, 'Invalid output option, must be type string'));
   });
   it('returns no error for valid output type', function() {
     validateArgs(goodUrl, {output: 'output.txt'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid parallelism type', function() {
-    validateArgs(goodUrl, {parallelism: '123'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {parallelism: '123'}, (err, data) => assert.equal(err.message, 'Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns error for zero parallelism', function() {
-    validateArgs(goodUrl, {parallelism: 0}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {parallelism: 0}, (err, data) => assert.equal(err.message, 'Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns error for float parallelism', function() {
-    validateArgs(goodUrl, {parallelism: 1.23}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+    validateArgs(goodUrl, {parallelism: 1.23}, (err, data) => assert.equal(err.message, 'Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
   });
   it('returns no error for valid parallelism type', function() {
     validateArgs(goodUrl, {parallelism: 123}, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
   it('returns error for invalid resume type', function() {
-    validateArgs(goodUrl, {resume: 'true'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid resume option, must be type boolean'));
+    validateArgs(goodUrl, {resume: 'true'}, (err, data) => assert.equal(err.message, 'Invalid resume option, must be type boolean'));
   });
   it('returns no error for valid resume type', function() {
     validateArgs(goodUrl, {resume: false}, (err, data) => assert.fail('Unexpected error: ' + err.message));

--- a/test/spoolchanges.js
+++ b/test/spoolchanges.js
@@ -1,0 +1,52 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+'use strict';
+
+const assert = require('assert');
+const nock = require('nock');
+
+const changes = require('../includes/spoolchanges.js');
+
+const url = 'http://localhost:7777';
+const dbName = 'fakenockdb';
+
+describe('#unit Check spool changes', function() {
+  it('should terminate on request error', function(done) {
+    nock(url)
+      .get(`/${dbName}/_changes`)
+      .query(true)
+      .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+    changes(`${url}/${dbName}`, '/dev/null', 500, null, function(err) {
+      assert.equal(err.name, 'SpoolChangesError');
+      assert.equal(err.message, 'Failed changes request - socket hang up');
+      done();
+    });
+  });
+
+  it('should terminate on bad HTTP status code repsonse', function(done) {
+    nock(url)
+      .get(`/${dbName}/_changes`)
+      .query(true)
+      .reply(500, {error: 'foo', reason: 'bar'});
+
+    changes(`${url}/${dbName}`, '/dev/null', 500, null, function(err) {
+      assert.equal(err.name, 'HTTPFatalError');
+      assert.equal(err.message, `500 : GET ${url}/${dbName}/_changes?seq_interval=10000`);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## What
Handle fatal errors in `spoolchanges.js`.

## How
- Add new `error` listener for change request.
- Invert error property `.isFatal` to `.isTransient` to ensure all unhandled errors are fatal.

## Testing
Includes additional unit tests.

## Issues
Fixes #135.
