### PR TITLE
Fixed issue with readstream destroy in restore.js (#147)

### DIFF
--- a/includes/restore.js
+++ b/includes/restore.js
@@ -27,7 +27,7 @@ module.exports = function(dbUrl, buffersize, parallelism, readstream, ee, callba
 
     var errHandler = function(err) {
       if (!err.isTransient) {
-        readstream.destroy();
+        readstream.emit('end');
       }
     };
 


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What

What was changed, e.g.
>Fixed issue with readstream destroy in restore.js for restore error handling during attachment stub missing issue.

## How

How the change was implemented and reasoning behind it, e.g.
> Modified readstream.destroy(); to readstream.emit('end');

## Testing

Tested with db's with attachment and restore error handler was able to successfully print the error.
```
info: Restore for DB 'test_status' failed due to errors - HTTPFatalError: 412 Precondition Failed: POST https://dph1007:7bd4416f6b3dc3c2ec57bef91233bef3363b45aec61d6f4b76ada12437d8abef@dph1007.cloudant.com/test_status/_bulk_docs - Error: missing_stub, Reason: Invalid attachment stub in 0077150069D1G79LL20 for test5.html
```
## Issues

#147
