### PR TITLE
147 restore error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
+
 - [NEW] Changed to use nodejs-cloudant for database requests.
+- [FIXED] An unhandled `readstream.destroy is not a function` error when trying
+  to terminate a restore process that encountered an error.
 
 # 2.0.0 (2017-07-04)
 

--- a/app.js
+++ b/app.js
@@ -254,6 +254,10 @@ module.exports = {
               // even though other errors may be received,
               // so deregister listeners now
               writer.removeAllListeners();
+              // Only call destroy if it is available on the stream
+              if (srcStream.destroy && srcStream.destroy instanceof Function) {
+                srcStream.destroy();
+              }
               callback(err);
             } else {
               ee.emit('error', err);

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -120,7 +120,7 @@ module.exports = function(db, bufferSize, parallelism, ee) {
     // it should contain an array of objects. The length of the array
     // depends on the bufferSize at backup time.
     linenumber++;
-    if (obj !== '') {
+    if (!didError && obj !== '') {
       // see if it parses as JSON
       try {
         var arr = JSON.parse(obj);


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What

Fixed uncaught `readstream.destroy is not a function` error.

## How

Called destroy only if it is available on the stream
*  Added check for `destroy()` function existence before calling.
* Added check for fatal `didError` flag in writer loop.
Moved restore error handling into `app.js` to benefit from existing
one call functionality.
Updated `removeListeners` call to remove only the error listeners.

## Testing

Added test for terminating a larger stream 
* Added an `InfiniteBackupStream` to avoid the whole stream having already been consumed by the test.
* Made `multiple fatal _bulk_docs error` test run for API only since the number of calls cannot be guaranteed for CLI case.
* Added parallelism arg to restore test utility.
* Reduced parallelism of `_bulk_docs HTTPFatalError` test.

## Issues

Fixes #147
