### PR TITLE
Added gzip for restore _bulk_docs POST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [NEW] Changed to use nodejs-cloudant for database requests.
+- [IMPROVED] Added compression to restore process requests.
 - [FIXED] An unhandled `readstream.destroy is not a function` error when trying
   to terminate a restore process that encountered an error.
 - [UPGRADED] Increased debug dependency to 3.0.x.

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -44,8 +44,7 @@ module.exports = function(db, bufferSize, parallelism, ee) {
       db: db.config.db,
       path: '_bulk_docs',
       method: 'POST',
-      headers: {'content-encoding': 'gzip'},
-      contentType: 'application/json'
+      headers: {'content-encoding': 'gzip'}
     }, function(err) {
       err = error.convertResponseError(err);
       if (err) {

--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -216,7 +216,8 @@ function restoreHttpError(opts, errorName, errorCode, done) {
         // Simulate the DB exists
         const n = nock(url).head('/fakenockdb').reply(200, {ok: true});
         // Simulate a 400 trying to write
-        n.post('/fakenockdb/_bulk_docs').reply(400, {error: 'bad_request', reason: 'testing bad response'});
+        // Provide a body function to handle the stream, but allow any body
+        n.post('/fakenockdb/_bulk_docs', function(body) { return true; }).reply(400, {error: 'bad_request', reason: 'testing bad response'});
         // Use only parallelism 1 so we don't have to mock up loads of responses
         const q = u.p(params, {opts: {parallelism: 1}, expectedRestoreError: {name: 'HTTPFatalError', code: 40}});
         u.testRestore(q, new InfiniteBackupStream(), 'fakenockdb', function(err) {
@@ -232,7 +233,8 @@ function restoreHttpError(opts, errorName, errorCode, done) {
         // Simulate the DB exists
         const n = nock(url).head('/fakenockdb').reply(200, {ok: true});
         // Simulate a 400 trying to write docs, 5 times because of default parallelism
-        n.post('/fakenockdb/_bulk_docs').times(5).reply(400, {error: 'bad_request', reason: 'testing bad response'});
+        // Provide a body function to handle the stream, but allow any body
+        n.post('/fakenockdb/_bulk_docs', function(body) { return true; }).times(5).reply(400, {error: 'bad_request', reason: 'testing bad response'});
         const q = u.p(params, {opts: {bufferSize: 1}, expectedRestoreError: {name: 'HTTPFatalError', code: 40}});
         restoreHttpError(q, 'HTTPFatalError', 40, done);
       });


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What

Added support for compressing _bulk_docs request bodies.

## How

Changed from `db.bulk` to a custom `_bulk_docs` request.
Added `gzip` `Content-Encoding` header.
Compressed the docs `payload` content using `zlib.createGzip()` and streaming the content through it.

## Testing

No new tests added, the restore requests are well exercised by the existing automated tests and those are passing.
I manually verified that the content length is smaller for requests using this branch.

## Issues

Fixes #54 
