### PR TITLE
Changed retry logic to nodejs-cloudant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+- [IMPROVED] Enhanced resilience of backup and restore processes by enabling the
+  nodejs-cloudant retry plugin.
 - [UPGRADED] Increased nodejs-cloudant dependency to 2.x.
 
 # 2.0.1 (2018-01-11)

--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ The `backup` function returns an event emitter. You can subscribe to:
 * `changes` - when a batch of changes has been written to log stream.
 * `written` - when a batch of documents has been written to backup stream.
 * `finished` - emitted once when all documents are backed up.
-* `error` - emitted when something goes wrong for a single batch.
 
 Backup data to a stream:
 
@@ -308,7 +307,6 @@ The `restore` function returns an event emitter. You can subscribe to:
 
 * `restored` - when a batch of documents is restored.
 * `finished` - emitted once when all documents are restored.
-* `error` - emitted when something goes wrong for a single batch.
 
 The backup file (or `srcStream`) contains lists comprising of document
 revisions, where each list is separated by a newline. The list length is

--- a/app.js
+++ b/app.js
@@ -177,16 +177,12 @@ module.exports = {
       // For errors we expect, may or may not be fatal
       .on('error', function(err) {
         debug('Error ' + JSON.stringify(err));
-        if (!err.isTransient) {
-          // These are fatal errors
-          // We only want to callback once for a fatal error
-          // even though other errors may be received,
-          // so deregister the listeners now
-          internalEE.removeAllListeners();
-          callback(err);
-        } else {
-          ee.emit('error', err);
-        }
+        // These are fatal errors
+        // We only want to callback once for a fatal error
+        // even though other errors may be received,
+        // so deregister the listeners now
+        internalEE.removeAllListeners();
+        callback(err);
       })
       .on('finished', function(obj) {
         function emitFinished() {
@@ -248,20 +244,16 @@ module.exports = {
             // For errors we expect, may or may not be fatal
             .on('error', function(err) {
               debug('Error ' + JSON.stringify(err));
-              if (!err.isTransient) {
-                // These are fatal errors
-                // We only want to callback once for a fatal error
-                // even though other errors may be received,
-                // so deregister listeners now
-                writer.removeAllListeners();
-                // Only call destroy if it is available on the stream
-                if (srcStream.destroy && srcStream.destroy instanceof Function) {
-                  srcStream.destroy();
-                }
-                callback(err);
-              } else {
-                ee.emit('error', err);
+              // These are fatal errors
+              // We only want to callback once for a fatal error
+              // even though other errors may be received,
+              // so deregister listeners now
+              writer.removeAllListeners();
+              // Only call destroy if it is available on the stream
+              if (srcStream.destroy && srcStream.destroy instanceof Function) {
+                srcStream.destroy();
               }
+              callback(err);
             })
             .on('finished', function(obj) {
               debug('restore complete');

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ function validateBulkGetSupport(db, callback) {
             // => supports /_bulk_get endpoint
             return;
           default:
-            return new error.HTTPFatalError(err);
+            return new error.HTTPError(err);
         }
       });
       callback(err);
@@ -135,10 +135,8 @@ function downloadRemainingBatches(log, db, ee, startTime, batchesPerDownloadSess
     readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, function(err, batchSetIds) {
       if (err) {
         ee.emit('error', err);
-        if (!err.isTransient) {
-          // Stop processing changes file for fatal errors
-          noRemainingBatches = true;
-        }
+        // Stop processing changes file for fatal errors
+        noRemainingBatches = true;
         done();
       } else {
         if (batchSetIds.length === 0) {
@@ -226,10 +224,8 @@ function processBatchSet(db, parallelism, log, batches, ee, start, grandtotal, c
       function(err, body) {
         if (err) {
           err = error.convertResponseError(err);
-          if (!err.isTransient) {
-            // Kill the queue for fatal errors
-            q.kill();
-          }
+          // Kill the queue for fatal errors
+          q.kill();
           ee.emit('error', err);
           done();
         } else {

--- a/includes/request.js
+++ b/includes/request.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ module.exports = {
     // Split the URL for use with nodejs-cloudant
     var actUrl = url.substr(0, url.lastIndexOf('/'));
     var dbName = url.substr(url.lastIndexOf('/') + 1);
+    // Default set of plugins
+    var pluginsToUse = ['retry'];
     return cloudant({url: actUrl,
+      plugins: pluginsToUse,
       requestDefaults: {
         agent: keepAliveAgent,
         headers: {'User-Agent': userAgent},

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,8 +57,8 @@ function exists(db, callback) {
         noDBErr.name = 'RestoreDatabaseNotFound';
         return noDBErr;
       } else {
-        // Delegate to the fatal error factory if it wasn't a 404
-        return error.convertResponseErrorToFatal(err);
+        // Delegate to the default error factory if it wasn't a 404
+        return error.convertResponseError(err);
       }
     });
     // Callback with or without (i.e. undefined) error

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ module.exports = function(dbUrl, limit, parallelism, log, resume) {
         if (err) {
           err = error.convertResponseError(err);
           ee.emit('error', err);
-          if (!err.isTransient) hasErrored = true; // fatal err
+          hasErrored = true;
           callback();
         } else if (!body.rows) {
           ee.emit('error', new error.BackupError(

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ module.exports = function(db, log, bufferSize, ee, callback) {
     .on('response', function(resp) {
       if (resp.statusCode >= 400) {
         changesRequest.abort();
-        callback(error.convertResponseErrorToFatal(resp));
+        callback(error.convertResponseError(resp));
       } else {
         resp.pipe(liner())
           .on('error', function(err) {

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,12 +66,8 @@ module.exports = function(db, bufferSize, parallelism, ee) {
     function taskCallback(err, payload) {
       if (err && !didError) {
         debug(`Queue task failed with error ${err.name}`);
-        if (err.isTransient) {
-          q.push(payload, taskCallback); // re-enqueue
-        } else {
-          didError = true;
-          q.kill();
-        }
+        didError = true;
+        q.kill();
         writer.emit('error', err);
       }
     }

--- a/test/app.js
+++ b/test/app.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/request.js
+++ b/test/request.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,24 +41,26 @@ describe('#unit Check request response error callback', function() {
     });
   });
 
-  it('should callback with error for 500 response', function(done) {
+  it('should callback with error after 3 500 responses', function(done) {
     var couch = nock(url)
       .get('/bad')
+      .times(3)
       .reply(500, {error: 'foo', reason: 'bar'});
 
     db.get('bad', function(err) {
       err = error.convertResponseError(err);
-      assert.equal(err.name, 'HTTPError');
+      assert.equal(err.name, 'HTTPFatalError');
       assert.equal(err.message, `500 : GET ${url}/bad - Error: foo, Reason: bar`);
       assert.ok(couch.isDone());
       done();
     });
   });
 
-  it('should callback with error for POST 503 response', function(done) {
+  it('should callback with error after 3 POST 503 responses', function(done) {
     var couch = nock(url)
       .post('/bad')
       .query(true)
+      .times(3)
       .reply(503, {error: 'service_unavailable', reason: 'Service unavailable'});
 
     db.server.request(
@@ -66,21 +68,22 @@ describe('#unit Check request response error callback', function() {
       function(err, body) {
         assert.ok(err);
         err = error.convertResponseError(err);
-        assert.equal(err.name, 'HTTPError');
+        assert.equal(err.name, 'HTTPFatalError');
         assert.equal(err.message, `503 : POST ${url}/bad - Error: service_unavailable, Reason: Service unavailable`);
         assert.ok(couch.isDone());
         done();
       });
   });
 
-  it('should callback with error for 429 response', function(done) {
+  it('should callback with error after 3 429 responses', function(done) {
     var couch = nock(url)
       .get('/bad')
+      .times(3)
       .reply(429, {error: 'foo', reason: 'bar'});
 
     db.get('bad', function(err) {
       err = error.convertResponseError(err);
-      assert.equal(err.name, 'HTTPError');
+      assert.equal(err.name, 'HTTPFatalError');
       assert.equal(err.message, `429 : GET ${url}/bad - Error: foo, Reason: bar`);
       assert.ok(couch.isDone());
       done();
@@ -100,53 +103,11 @@ describe('#unit Check request response error callback', function() {
       done();
     });
   });
-});
-
-describe('#unit Check request response fatal error callback', function() {
-  it('should not callback with fatal error for 200 response', function(done) {
-    var couch = nock(url)
-      .get('/good')
-      .reply(200, {ok: true});
-
-    db.get('good', function(err) {
-      err = error.convertResponseErrorToFatal(err);
-      assert.equal(err, null);
-      assert.ok(couch.isDone());
-      done();
-    });
-  });
-
-  it('should callback with fatal error for 500 response', function(done) {
-    var couch = nock(url)
-      .get('/bad')
-      .reply(500, {error: 'foo', reason: 'bar'});
-
-    db.get('bad', function(err) {
-      err = error.convertResponseErrorToFatal(err);
-      assert.equal(err.name, 'HTTPFatalError');
-      assert.equal(err.message, `500 : GET ${url}/bad - Error: foo, Reason: bar`);
-      assert.ok(couch.isDone());
-      done();
-    });
-  });
-
-  it('should callback with fatal error for 404 response', function(done) {
-    var couch = nock(url)
-      .get('/bad')
-      .reply(404, {error: 'foo', reason: 'bar'});
-
-    db.get('bad', function(err) {
-      err = error.convertResponseErrorToFatal(err);
-      assert.equal(err.name, 'HTTPFatalError');
-      assert.equal(err.message, `404 : GET ${url}/bad - Error: foo, Reason: bar`);
-      assert.ok(couch.isDone());
-      done();
-    });
-  });
 
   it('should callback with same error for no status code error response', function(done) {
     var couch = nock(url)
       .get('/bad')
+      .times(3)
       .replyWithError('testing badness');
 
     db.get('bad', function(err) {

--- a/test/shallowbackup.js
+++ b/test/shallowbackup.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,13 +94,7 @@ describe('#unit Perform backup using shallow backup', function() {
       .query({limit: 3, startkey: snipeKey, include_docs: true})
       .reply(200, JSON.parse(fs.readFileSync('./test/fixtures/animaldb_all_docs_4.json', 'utf8')));
 
-    var errCount = 0;
-
     backup(dbUrl, 3, 1, null, null)
-      .on('error', function(err) {
-        errCount++;
-        assert.equal(err.name, 'HTTPError');
-      })
       .on('received', function(data) {
         if (data.batch === 3) {
           assert.equal(data.length, 2); // smaller last batch
@@ -111,7 +105,6 @@ describe('#unit Perform backup using shallow backup', function() {
       .on('finished', function(data) {
         assert.equal(data.total, 11);
         assert.ok(couch.isDone());
-        assert.equal(errCount, 1);
         done();
       });
   });

--- a/test/spoolchanges.js
+++ b/test/spoolchanges.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ describe('#unit Check spool changes', function() {
     nock(url)
       .get(`/${dbName}/_changes`)
       .query(true)
+      .times(3)
       .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
 
     changes(db, '/dev/null', 500, null, function(err) {
@@ -43,6 +44,7 @@ describe('#unit Check spool changes', function() {
     nock(url)
       .get(`/${dbName}/_changes`)
       .query(true)
+      .times(3)
       .reply(500, {error: 'foo', reason: 'bar'});
 
     changes(db, '/dev/null', 500, null, function(err) {


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_ - *N/A*
- [x] You have completed the PR template below:

## What

Changed retry logic to nodejs-cloudant.

## How

Instead of handling retries internally, delegate to nodejs-cloudant's `retry` plugin.
i) Configured `retry` plugin.
ii) Removed transient `HTTPError` errors and associated events.
iii) Updated `README` for errors no longer being emitted.

*For consideration by reviewers*
The couchbackup API no longer emits `error` events for transient errors. It could be argued that this is a breaking change, but the previous code and this new version both retry the transient error anyway. It's possible (but doubtful given the lack of a functioning cancellation API) that users were cancelling backups on transient errors, which would not longer be possible.

## Testing

iv) Updated tests for appropriate default retry numbers.
v) Removed obsolete transient callback tests and merged with associated failure callback tests.

## Issues

Should prevent errors like #154 
Part of #173 
