### PR TITLE
Fix failure to decompress a gzipped /_changes response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # 2.2.0 (UNRELEASED)
+- [FIXED] An issue where the `_changes` response stream doesn't get correctly
+  decompressed.
 - [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.
 
 # 2.1.0 (2018-02-20)

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -71,7 +71,7 @@ module.exports = function(db, log, bufferSize, ee, callback) {
         changesRequest.abort();
         callback(error.convertResponseError(resp));
       } else {
-        resp.pipe(liner())
+        changesRequest.pipe(liner())
           .on('error', function(err) {
             callback(err);
           })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.1.1-SNAPSHOT",
+  "version": "2.2.0-SNAPSHOT",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",
@@ -23,7 +23,7 @@
     "async": "2.6.0",
     "commander": "^2.9.0",
     "debug": "~3.1.0",
-    "@cloudant/cloudant": "^2.0.2",
+    "@cloudant/cloudant": "^2.1.0",
     "tmp": "0.0.33"
   },
   "main": "app.js",


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What
Fix failure to decompress a gzipped `/_changes` response.

_TODO: Bump @cloudant/cloudant dependancy following release of `2.1.0`._

## Issues
Fixes #196.
