### PR TITLE
Prepare 2.2.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 2.2.0 (UNRELEASED)
+# 2.2.0 (2018-03-06)
 - [FIXED] An issue where the `_changes` response stream doesn't get correctly
   decompressed.
 - [FIXED] Prevent duplicate execution of backup error callbacks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.2.0-SNAPSHOT",
+  "version": "2.2.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# 2.2.0 (2018-03-06)
- [FIXED] An issue where the _changes response stream doesn't get correctly decompressed.
- [FIXED] Prevent duplicate execution of backup error callbacks.
- [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.