### PR TITLE
Fixed error handling issues exposed in Node 10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # 2.3.0 (UNRELEASED)
+- [FIXED] Intermittent issues with multiple callbacks, particularly noticeable
+ when using Node.js 10.
+- [FIXED] Issue where a success message could confusingly be output after a
+ fatal error.
 
 # 2.2.0 (2018-03-06)
 

--- a/test/ci_error.js
+++ b/test/ci_error.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,23 +22,24 @@ const u = require('./citestutils.js');
 describe('Write error tests', function() {
   it('calls callback with error set when stream is not writeable', function(done) {
     u.setTimeout(this, 10);
-    const dirname = fs.mkdtempSync('test_backup');
-    // make temp dir not writeable
-    fs.chmodSync(dirname, 0);
+    const dirname = fs.mkdtempSync('test_backup_');
+    // make temp dir read only
+    fs.chmodSync(dirname, 0o444);
     const filename = dirname + '/test.backup';
     const backupStream = fs.createWriteStream(filename, {flags: 'w'});
     const params = {useApi: true};
     // try to do backup and check err was set in callback
-    u.testBackup(params, 'animaldb', backupStream, function(err) {
+    u.testBackup(params, 'animaldb', backupStream, function(resultErr) {
+      var err = null;
       try {
         // cleanup temp dir
-        fs.chmodSync(dirname, 0x1B6); // 666 in octal
         fs.rmdirSync(dirname);
         // error should have been set
-        assert.ok(err != null);
-        assert.equal(err.code, 'EACCES');
-        done();
-      } catch (err) {
+        assert.ok(resultErr);
+        assert.equal(resultErr.code, 'EACCES');
+      } catch (thrownErr) {
+        err = thrownErr;
+      } finally {
         done(err);
       }
     });

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -113,17 +113,17 @@ function testBackup(params, databaseName, outputStream, callback) {
         if (params.expectedBackupError) {
           try {
             assert.equal(err.name, params.expectedBackupError.name, `The backup should receive the expected error.`);
-            callback();
-          } catch (err) {
-            callback(err);
+            // Got the expected error, so wipe it for the callback
+            err = null;
+          } catch (caught) {
+            // Update the error with the assertion failure
+            err = caught;
           }
-        } else {
-          callback(err);
         }
       } else {
         console.log(data);
-        callback();
       }
+      callback(err);
     });
     if (backup) {
       backup.on('error', function(err) {
@@ -272,17 +272,15 @@ function testRestore(params, inputStream, databaseName, callback) {
         if (params.expectedRestoreError) {
           try {
             assert.equal(err.name, params.expectedRestoreError.name, `The restore should receive the expected error.`);
-            callback();
-          } catch (err) {
-            callback(err);
+            err = null;
+          } catch (caught) {
+            err = caught;
           }
-        } else {
-          callback(err);
         }
       } else {
         console.log(data);
-        callback();
       }
+      callback(err);
     }).on('error', function(err) {
       console.error(`Caught non-fatal error: ${err}`);
     });


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What

Fixed issue with events still being processed after a `callback(err)` for a fatal error that should have terminated the program.

## How

The event driven nature of this library means that events may still be processed after receiving a fatal error event. Node.js version 10 seems to have particularly exposed this problem. The documentation of `removeAllListeners()` has been clarified in Node and it is made clear that this is not an appropriate function for the behaviour we need of preventing further event handling after a fatal error. The usage of `removeAllListeners()` has been removed.

* Added `addEventListener` function that wraps listeners in error flag checking to avoid emitting errors more than once and stop all further callbacks after an error.
* Added additional `didError` to stop writing earlier if there is an error during restore.
* Updated CHANGES.md.

## Testing

The changes were exposed by existing testing once it was running on Node.js 10.

Updated not-writeable test that was particularly vulnerable to these issues to make it easier to debug and more reliable:
* Removed unnecessary reversion of permissions.
* Made error handling and assertion more clear in not-writeable test.
* Simplified common test callbacks.

## Issues

N/A; PR raised in response to CI failures.
