### PR TITLE
Corrected name of iamTokenUrl option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [FIXED] IAM token URL override option.
+
 # 2.3.0 (2018-05-22)
 
 - [NEW] Check for database existence before starting backup. This provides for

--- a/README.md
+++ b/README.md
@@ -197,7 +197,11 @@ This tool can be used to script the backup of your databases. Move the backup an
  `https://iam.bluemix.net/identity/token`, but can be overridden if necessary using the `CLOUDANT_IAM_TOKEN_URL` environment variable.
 * `DEBUG` - if set to `couchbackup`, all debug messages will be sent to `stderr` during a backup or restore process
 
-### Command-line paramters
+_Note:_ These environment variables can only be used with the CLI. When
+[using programmatically](#using-programmatically) the `opts` dictionary must be
+used.
+
+### Command-line parameters
 
 * `--url` - same as `COUCH_URL` environment variable
 * `--db` - same as `COUCH_DATABASE`
@@ -248,8 +252,8 @@ target locations are not required.
 * `resume`: see `COUCH_RESUME`.
 * `mode`: see `COUCH_MODE`.
 * `iamApiKey`: see `CLOUDANT_IAM_API_KEY`.
-* `iamTokenUrl` : may be used with `key` to override the default URL for
-  retrieving IAM tokens.
+* `iamTokenUrl`: may be used with `iamApiKey` to override the default URL for
+ retrieving IAM tokens.
 
 The callback has the standard `err, data` parameters and is called when
 the backup completes or fails.
@@ -308,6 +312,9 @@ target locations are not required.
 
 * `parallelism`: see `COUCH_PARALLELISM`.
 * `bufferSize`: see `COUCH_BUFFER_SIZE`.
+* `iamApiKey`: see `CLOUDANT_IAM_API_KEY`.
+* `iamTokenUrl`: may be used with `iamApiKey` to override the default URL for
+ retrieving IAM tokens.
 
 The callback has the standard `err, data` parameters and is called when
 the restore completes or fails.

--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -31,7 +31,8 @@ var opts = {
   mode: program.mode,
   parallelism: program.parallelism,
   resume: program.resume,
-  iamApiKey: program.iamApiKey
+  iamApiKey: program.iamApiKey,
+  iamTokenUrl: program.iamTokenUrl
 };
 
 // log configuration to console

--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -26,7 +26,8 @@ var databaseUrl = cliutils.databaseUrl(program.url, program.db);
 var opts = {
   bufferSize: program.bufferSize,
   parallelism: program.parallelism,
-  iamApiKey: program.iamApiKey
+  iamApiKey: program.iamApiKey,
+  iamTokenUrl: program.iamTokenUrl
 };
 
 // log configuration to console

--- a/includes/parser.js
+++ b/includes/parser.js
@@ -58,6 +58,9 @@ function parseBackupArgs() {
       defaults.url)
     .parse(process.argv);
 
+  // Special case the iamTokenUrl which is only an env var
+  program.iamTokenUrl = defaults.iamTokenUrl;
+
   if (program.resume && (program.log === defaults.log)) {
     // If resuming and the log file arg is the newly generated tmp name from defaults then we know that --log wasn't specified.
     // We have to do this check here for the CLI case because of the default.
@@ -93,6 +96,9 @@ function parseRestoreArgs() {
       cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url),
       defaults.url)
     .parse(process.argv);
+
+  // Special case the iamTokenUrl which is only an env var
+  program.iamTokenUrl = defaults.iamTokenUrl;
 
   return program;
 }

--- a/includes/request.js
+++ b/includes/request.js
@@ -37,8 +37,8 @@ module.exports = {
     // Default to cookieauth unless an IAM key is provided
     if (opts.iamApiKey) {
       const iamPluginConfig = {iamApiKey: opts.iamApiKey};
-      if (opts.iamTokenEndpoint) {
-        iamPluginConfig.iamTokenEndpoint = opts.iamTokenEndpoint;
+      if (opts.iamTokenUrl) {
+        iamPluginConfig.iamTokenUrl = opts.iamTokenUrl;
       }
       pluginsToUse.push({iamauth: iamPluginConfig});
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.3.0-SNAPSHOT",
+  "version": "2.3.1-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -206,11 +206,11 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.10"
       }
     },
     "asynckit": {


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/couchbackup/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#testing) for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have updated the [.npmignore](https://github.com/cloudant/couchbackup/blob/master/.npmignore) _(if applicable)_
- [x] You have completed the PR template below:

## What

Corrected name of `iamTokenUrl` option

## How

Changed name from `iamTokenEndpoint` to `iamTokenUrl`.

## Testing

The `config.js` already asserts the correct name. The override is being tested as part of IAM acceptance testing.

## Issues

N/A
