### PR TITLE
Prepare for 2.3.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.3.1 (2018-06-15)
 
 - [FIXED] Concurrent database backups use the same default log file.
 - [FIXED] IAM token URL override option.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.3.1-SNAPSHOT",
+  "version": "2.3.1",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.3.1 release

# Changes
# 2.3.1 (2018-06-15)

- [FIXED] Concurrent database backups use the same default log file.
- [FIXED] IAM token URL override option.
