### PR TITLE
Changed to npm install for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "node"
   - "8"
   - "6"
+install: npm install


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Changed Travis to use `npm install` for compatibility with `package-lock`.

Preemptively fixes the same [style of issue observed in `cloudant-follow`](https://github.com/cloudant-labs/cloudant-follow/issues/78) for greenkeeper branches

## Approach

Travis uses `npm ci` by default, which does not update the `package-lock` file. Changed the `install` step to explicitly use `npm install`:

```yaml
install: npm install
```

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
