### PR TITLE
Added gkLockfile to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,6 +120,8 @@ stage('QA') {
 
 // Publish the master branch
 stage('Publish') {
+  // Update the package-lock for greenkeeper branches
+  gkLockfile {}
   if (env.BRANCH_NAME == "master") {
     node {
       unstash 'built'


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Add `gkLockfile` call to `Jenkinsfile` for running `greenkeeper-lockfile` for automatic `package-lock` updates on greenkeeper branches.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

See Greenkeeper PRs.

### 2. What you expected to happen

`package-lock` file to get updated for dependency changes.

### 3. What actually happened

`package-lock` is not updated.

## Approach

Greenkeeper provides a `greenkeeper-lockfile` package to check for dependency changes and push an additional commit that updates the lockfile. The running of this package is in our global Jenkins shared library, this PR simply adds a stage to invoke that.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
