### PR TITLE
Request timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.4.0
+
+- [NEW] Added request timeout option
+
 # 2.3.1 (2018-06-15)
 
 - [FIXED] Concurrent database backups use the same default log file.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # 2.4.0
 
-- [NEW] Added request timeout option
+- [NEW] Added request timeout option. Set via env var `COUCH_REQUEST_TIMEOUT`,
+ as CLI option `--request-timeout`, or prograimmatically via
+ `options.requestTimeout`
 
 # 2.3.1 (2018-06-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # 2.4.0
 
 - [NEW] Added request timeout option. Set via env var `COUCH_REQUEST_TIMEOUT`,
- as CLI option `--request-timeout`, or prograimmatically via
+ as CLI option `--request-timeout`, or programmatically via
  `options.requestTimeout`
 
 # 2.3.1 (2018-06-15)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This tool can be used to script the backup of your databases. Move the backup an
 * `COUCH_DATABASE` - the name of the database to act upon e.g. `mydb` (default `test`)
 * `COUCH_PARALLELISM` - the number of HTTP requests to perform in parallel when restoring a backup e.g. `10` (Default `5`)
 * `COUCH_BUFFER_SIZE` - the number of documents fetched and restored at once e.g. `100` (default `500`)
-* `COUCH_REQUEST_TIMEOUT` - the number of milliseconds to wait for a respose to a HTTP request before retrying the request e.g. `10000` (Default `300000`)
+* `COUCH_REQUEST_TIMEOUT` - the number of milliseconds to wait for a respose to a HTTP request before retrying the request e.g. `10000` (Default `120000`)
 * `COUCH_LOG` - the file to store logging information during backup
 * `COUCH_RESUME` - if `true`, resumes a previous backup from its last known position
 * `COUCH_OUTPUT` - the file name to store the backup data (defaults to stdout)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This tool can be used to script the backup of your databases. Move the backup an
 * `COUCH_DATABASE` - the name of the database to act upon e.g. `mydb` (default `test`)
 * `COUCH_PARALLELISM` - the number of HTTP requests to perform in parallel when restoring a backup e.g. `10` (Default `5`)
 * `COUCH_BUFFER_SIZE` - the number of documents fetched and restored at once e.g. `100` (default `500`)
+* `COUCH_REQUEST_TIMEOUT` - the number of milliseconds to wait for a respose to a HTTP request before retrying the request e.g. `10000` (Default `300000`)
 * `COUCH_LOG` - the file to store logging information during backup
 * `COUCH_RESUME` - if `true`, resumes a previous backup from its last known position
 * `COUCH_OUTPUT` - the file name to store the backup data (defaults to stdout)
@@ -207,6 +208,7 @@ used.
 * `--db` - same as `COUCH_DATABASE`
 * `--parallelism` - same as `COUCH_PARALLELISM`
 * `--buffer-size` - same as `COUCH_BUFFER_SIZE`
+* `--request-timeout` - same as `COUCH_REQUEST_TIMEOUT`
 * `--log` - same as `COUCH_LOG`
 * `--resume` - same as `COUCH_RESUME`
 * `--output` - same as `COUCH_OUTPUT`
@@ -248,6 +250,7 @@ target locations are not required.
 
 * `parallelism`: see `COUCH_PARALLELISM`.
 * `bufferSize`: see `COUCH_BUFFER_SIZE`.
+* `requestTimeout`: see `COUCH_REQUEST_TIMEOUT`.
 * `log`: see `COUCH_LOG`.
 * `resume`: see `COUCH_RESUME`.
 * `mode`: see `COUCH_MODE`.
@@ -312,6 +315,7 @@ target locations are not required.
 
 * `parallelism`: see `COUCH_PARALLELISM`.
 * `bufferSize`: see `COUCH_BUFFER_SIZE`.
+* `requestTimeout`: see `COUCH_REQUEST_TIMEOUT`.
 * `iamApiKey`: see `CLOUDANT_IAM_API_KEY`.
 * `iamTokenUrl`: may be used with `iamApiKey` to override the default URL for
  retrieving IAM tokens.

--- a/app.js
+++ b/app.js
@@ -84,6 +84,10 @@ function validateArgs(url, opts, cb) {
     cb(new error.BackupError('InvalidOption', 'Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
     return;
   }
+  if (opts && typeof opts.requestTimeout !== 'undefined' && !isSafePositiveInteger(opts.requestTimeout)) {
+    cb(new error.BackupError('InvalidOption', 'Invalid request timeout option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'), null);
+    return;
+  }
   if (opts && typeof opts.resume !== 'undefined' && typeof opts.resume !== 'boolean') {
     cb(new error.BackupError('InvalidOption', 'Invalid resume option, must be type boolean'), null);
     return;
@@ -174,6 +178,7 @@ module.exports = {
    * @param {object} opts - Backup options.
    * @param {number} [opts.parallelism=5] - Number of parallel HTTP requests to use.
    * @param {number} [opts.bufferSize=500] - Number of documents per batch request.
+   * @param {number} [opts.requestTimeout=300000] - Milliseconds to wait before retrying a HTTP request.
    * @param {string} [opts.iamApiKey] - IAM API key to use to access Cloudant database.
    * @param {string} [opts.log] - Log file name. Default uses a temporary file.
    * @param {boolean} [opts.resume] - Whether to resume from existing log.
@@ -295,6 +300,7 @@ module.exports = {
    * @param {object} opts - Restore options.
    * @param {number} opts.parallelism - Number of parallel HTTP requests to use. Default 5.
    * @param {number} opts.bufferSize - Number of documents per batch request. Default 500.
+   * @param {number} opts.requestTimeout - Milliseconds to wait before retrying a HTTP request. Default 300000.
    * @param {string} opts.iamApiKey - IAM API key to use to access Cloudant database.
    * @param {backupRestoreCallback} callback - Called on completion.
    */

--- a/app.js
+++ b/app.js
@@ -178,7 +178,7 @@ module.exports = {
    * @param {object} opts - Backup options.
    * @param {number} [opts.parallelism=5] - Number of parallel HTTP requests to use.
    * @param {number} [opts.bufferSize=500] - Number of documents per batch request.
-   * @param {number} [opts.requestTimeout=300000] - Milliseconds to wait before retrying a HTTP request.
+   * @param {number} [opts.requestTimeout=120000] - Milliseconds to wait before retrying a HTTP request.
    * @param {string} [opts.iamApiKey] - IAM API key to use to access Cloudant database.
    * @param {string} [opts.log] - Log file name. Default uses a temporary file.
    * @param {boolean} [opts.resume] - Whether to resume from existing log.
@@ -300,7 +300,7 @@ module.exports = {
    * @param {object} opts - Restore options.
    * @param {number} opts.parallelism - Number of parallel HTTP requests to use. Default 5.
    * @param {number} opts.bufferSize - Number of documents per batch request. Default 500.
-   * @param {number} opts.requestTimeout - Milliseconds to wait before retrying a HTTP request. Default 300000.
+   * @param {number} opts.requestTimeout - Milliseconds to wait before retrying a HTTP request. Default 120000.
    * @param {string} opts.iamApiKey - IAM API key to use to access Cloudant database.
    * @param {backupRestoreCallback} callback - Called on completion.
    */

--- a/bin/couchbackup.bin.js
+++ b/bin/couchbackup.bin.js
@@ -30,6 +30,7 @@ var opts = {
   log: program.log,
   mode: program.mode,
   parallelism: program.parallelism,
+  requestTimeout: program.requestTimeout,
   resume: program.resume,
   iamApiKey: program.iamApiKey,
   iamTokenUrl: program.iamTokenUrl

--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -26,6 +26,7 @@ var databaseUrl = cliutils.databaseUrl(program.url, program.db);
 var opts = {
   bufferSize: program.bufferSize,
   parallelism: program.parallelism,
+  requestTimeout: program.requestTimeout,
   iamApiKey: program.iamApiKey,
   iamTokenUrl: program.iamTokenUrl
 };

--- a/includes/config.js
+++ b/includes/config.js
@@ -23,6 +23,7 @@ function apiDefaults() {
   return {
     parallelism: 5,
     bufferSize: 500,
+    requestTimeout: 300000,
     log: tmp.fileSync().name,
     resume: false,
     mode: 'full'
@@ -64,6 +65,11 @@ function applyEnvironmentVariables(opts) {
   // if we have a specified parallelism
   if (typeof process.env.COUCH_PARALLELISM !== 'undefined') {
     opts.parallelism = parseInt(process.env.COUCH_PARALLELISM);
+  }
+
+  // if we have a specified request timeout
+  if (typeof process.env.COUCH_REQUEST_TIMEOUT !== 'undefined') {
+    opts.requestTimeout = parseInt(process.env.COUCH_REQUEST_TIMEOUT);
   }
 
   // if we have a specified log file

--- a/includes/config.js
+++ b/includes/config.js
@@ -23,7 +23,7 @@ function apiDefaults() {
   return {
     parallelism: 5,
     bufferSize: 500,
-    requestTimeout: 300000,
+    requestTimeout: 120000,
     log: tmp.fileSync().name,
     resume: false,
     mode: 'full'

--- a/includes/parser.js
+++ b/includes/parser.js
@@ -53,6 +53,9 @@ function parseBackupArgs() {
     .option('-r, --resume',
       cliutils.getUsage('continue a previous backup from its last known position', defaults.resume),
       defaults.resume)
+    .option('-t, --request-timeout <n>',
+      cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
+      Number, defaults.requestTimeout)
     .option('-u, --url <url>',
       cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url),
       defaults.url)
@@ -92,6 +95,9 @@ function parseRestoreArgs() {
     .option('-p, --parallelism <n>',
       cliutils.getUsage('number of HTTP requests to perform in parallel when restoring a backup', defaults.parallelism),
       Number, defaults.parallelism)
+    .option('-t, --request-timeout <n>',
+      cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
+      Number, defaults.requestTimeout)
     .option('-u, --url <url>',
       cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url),
       defaults.url)

--- a/includes/request.js
+++ b/includes/request.js
@@ -49,7 +49,8 @@ module.exports = {
       requestDefaults: {
         agent: keepAliveAgent,
         headers: { 'User-Agent': userAgent },
-        gzip: true
+        gzip: true,
+        timeout: opts.requestTimeout
       } }).use(dbName);
   }
 };

--- a/test/app.js
+++ b/test/app.js
@@ -90,6 +90,18 @@ describe('#unit Validate arguments', function() {
   it('returns no error for valid parallelism type', function() {
     validateArgs(goodUrl, { parallelism: 123 }, (err, data) => assert.fail('Unexpected error: ' + err.message));
   });
+  it('returns error for invalid request timeout type', function() {
+    validateArgs(goodUrl, { requestTimeout: '123' }, (err, data) => assert.strictEqual(err.message, 'Invalid request timeout option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for zero request timeout', function() {
+    validateArgs(goodUrl, { requestTimeout: 0 }, (err, data) => assert.strictEqual(err.message, 'Invalid request timeout option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for float request timout', function() {
+    validateArgs(goodUrl, { requestTimeout: 1.23 }, (err, data) => assert.strictEqual(err.message, 'Invalid request timeout option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns no error for valid request timeout type', function() {
+    validateArgs(goodUrl, { requestTimeout: 123 }, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
   it('returns error for invalid resume type', function() {
     validateArgs(goodUrl, { resume: 'true' }, (err, data) => assert.strictEqual(err.message, 'Invalid resume option, must be type boolean'));
   });

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -296,6 +296,10 @@ function testRestore(params, inputStream, databaseName, callback) {
         args.push('--parallelism');
         args.push(params.opts.parallelism);
       }
+      if (params.opts.requestTimeout) {
+        args.push('--request-timeout');
+        args.push(params.opts.requestTimeout);
+      }
       if (params.opts.iamApiKey) {
         args.push('--iam-api-key');
         args.push(params.opts.iamApiKey);

--- a/test/config.js
+++ b/test/config.js
@@ -66,6 +66,15 @@ describe('#unit Configuration', function() {
     done();
   });
 
+  it('respects the COUCH_REQUEST_TIMEOUT env variable', function(done) {
+    process.env.COUCH_REQUEST_TIMEOUT = '10000';
+    var config = {};
+    applyEnvVars(config);
+    assert.strictEqual(typeof config.requestTimeout, 'number');
+    assert.strictEqual(config.requestTimeout, 10000);
+    done();
+  });
+
   it('respects the CLOUDANT_IAM_API_KEY env variable', function(done) {
     const key = 'ABC123-ZYX987_cba789-xyz321';
     process.env.CLOUDANT_IAM_API_KEY = key;

--- a/test/parser.js
+++ b/test/parser.js
@@ -32,6 +32,7 @@ describe('#unit Default parameters', function() {
     process.env.COUCH_DATABASE = 'mydb';
     process.env.COUCH_BUFFER_SIZE = '1000';
     process.env.COUCH_PARALLELISM = '20';
+    process.env.COUCH_REQUEST_TIMEOUT = '20000';
     process.env.COUCH_LOG = 'my.log';
     process.env.COUCH_RESUME = 'true';
     process.env.COUCH_OUTPUT = 'myfile.txt';
@@ -78,6 +79,14 @@ describe('#unit Default parameters', function() {
       var program = parser.parseBackupArgs();
       assert.strictEqual(typeof program.parallelism, 'number');
       assert.strictEqual(program.parallelism, parseInt(process.env.COUCH_PARALLELISM, 10));
+      done();
+    });
+
+    it('respects the COUCH_REQUEST_TIMEOUT env variable if the --request-timeout backup command-line parameter is missing', function(done) {
+      process.argv = ['node', 'test'];
+      var program = parser.parseBackupArgs();
+      assert.strictEqual(typeof program.requestTimeout, 'number');
+      assert.strictEqual(program.requestTimeout, parseInt(process.env.COUCH_REQUEST_TIMEOUT, 10));
       done();
     });
 
@@ -146,6 +155,15 @@ describe('#unit Default parameters', function() {
       var program = parser.parseBackupArgs();
       assert.strictEqual(typeof program.parallelism, 'number');
       assert.strictEqual(program.parallelism, parallelism);
+      done();
+    });
+
+    it('respects the backup --request-timeout command-line parameter', function(done) {
+      var requestTimeout = 10000;
+      process.argv = ['node', 'test', '--request-timeout', requestTimeout];
+      var program = parser.parseBackupArgs();
+      assert.strictEqual(typeof program.requestTimeout, 'number');
+      assert.strictEqual(program.requestTimeout, requestTimeout);
       done();
     });
 
@@ -226,6 +244,14 @@ describe('#unit Default parameters', function() {
       done();
     });
 
+    it('respects the COUCH_REQUEST_TIMEOUT env variable if the --request-timeout restore command-line parameter is missing', function(done) {
+      process.argv = ['node', 'test'];
+      var program = parser.parseRestoreArgs();
+      assert.strictEqual(typeof program.requestTimeout, 'number');
+      assert.strictEqual(program.requestTimeout, parseInt(process.env.COUCH_REQUEST_TIMEOUT, 10));
+      done();
+    });
+
     it('respects the CLOUDANT_IAM_API_KEY env variable if the --iam-api-key restore command-line parameter is missing', function(done) {
       process.argv = ['node', 'test'];
       var program = parser.parseRestoreArgs();
@@ -267,6 +293,15 @@ describe('#unit Default parameters', function() {
       var program = parser.parseRestoreArgs();
       assert.strictEqual(typeof program.parallelism, 'number');
       assert.strictEqual(program.parallelism, parallelism);
+      done();
+    });
+
+    it('respects the restore --request-timeout command-line parameter', function(done) {
+      var requestTimeout = 10000;
+      process.argv = ['node', 'test', '--request-timeout', requestTimeout];
+      var program = parser.parseRestoreArgs();
+      assert.strictEqual(typeof program.requestTimeout, 'number');
+      assert.strictEqual(program.requestTimeout, requestTimeout);
       done();
     });
 


### PR DESCRIPTION
## Checklist
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
When running a backup it can take a very long time for the Cloudant server to respond to a `/_bulk_get` request (e.g. if it encounters a `500 Internal error`). There is no way to set a timeout without modifying the source code.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
1. Have a CouchDB server that takes a very long time respond to a `/_bulk_get` request
1.1. We ran CouchDB at our Cloudant cluster smrt003 which yeilded `500 Internal errors` every now and then when using the default `couchbackup` option `opts.batchSize=500`
2. Run the example script `node ./examples/s3-backup-stream.js --source https://user:pass@example.com/my_database --bucket my_bucket --s3url s3.amazonaws.com --awsprofile default` with default `couchbackup` options.

### 2. What you expected to happen
Backup `/_bulk_get` requests in `./includes/backup.js` should happen in a timely manner. 

If they dont (i.e. the server takes a very long time to respond) it should be possible to set a timeout for the HTTP requests.

### 3. What actually happened
Backup can idle for ~5 minutes without giving any information about what is happening before retrying (and succeeding) after first receiving a `500 Internal error`.

No way to set a timeout without modifying the source code.

## Approach
By supplying an argument `requestTimeout` to either the backup or restore function, a timeout can be set globally for all outgoing HTTP requests stemming from the `db` object. This is set in `./includes/request.js` by adding the `timeout` option to the `requestDefaults`. See [`request.request timeout`](https://github.com/request/request#requestoptions-callback). The argument `requestTimeout` is implemented as a new API option (see below).

## Schema & API Changes
Added the new option request timeout as:
- Environment variable COUCH_REQUEST_TIMEOUT`
- CLI argument `--request-timeout`
- Programmatically `opts.requestTimeout`

The default value is set to 120 seconds (reasonable & upper limit according to [`request.request timeout`](https://github.com/request/request#requestoptions-callback)).

## Security and Privacy
No change.

## Testing
Added new tests relating to new option:
- `test/app.js`
  - 'returns error for invalid request timeout type'
  - 'returns error for zero request timeout'
  - 'returns error for float request timout'
  - 'returns no error for valid request timeout type'
- `test/config.js`
  - 'respects the COUCH_REQUEST_TIMEOUT env variable'
- `test/parser.js`
  - 'respects the COUCH_REQUEST_TIMEOUT env variable if the --request-timeout backup command-line parameter is missing'
  - 'respects the backup --request-timeout command-line parameter'
  - 'respects the COUCH_REQUEST_TIMEOUT env variable if the --request-timeout restore command-line parameter is missing'
  - 'respects the restore --request-timeout command-line parameter'

Added new tests relating to the timeout:
- `test/request.js`
  - 'should retry request if HTTP request gets timed out'
  - ''should callback with error code ESOCKETTIMEDOUT if 3 HTTP requests gets timed out''

## Monitoring and Logging
No change.