### PR TITLE
Proposed 2.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 2.4.0 (2019-03-15)
 
 - [NEW] Added request timeout option. Set via env var `COUCH_REQUEST_TIMEOUT`,
  as CLI option `--request-timeout`, or programmatically via

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.3.2-SNAPSHOT",
+  "version": "2.4.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.4.0 release

# Changes
- [NEW] Added request timeout option. Set via env var `COUCH_REQUEST_TIMEOUT`,
 as CLI option `--request-timeout`, or programmatically via
 `options.requestTimeout`.
- [IMPROVED] Replaced usages of Node.js legacy URL API. Note this changes some
  URL validation error messages.
- [IMPROVED] Documentation, help text and log warnings for invalid options in
  "shallow" mode.
- [UPGRADED] Moved nodejs-cloudant dependency to 4.x.x.