### PR TITLE
Prepare for release 2.4.2.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 2.4.2 (2019-08-20)
 
 - [FIXED] Preserve document revisions in shallow backup.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 2.4.2 (2019-08-20)
 
 - [FIXED] Preserve document revisions in shallow backup.
+- [UPGRADED] Upgraded commander dependency to version 3.0.0.
 
 # 2.4.1 (2019-06-18)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.4.2-SNAPSHOT",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.4.2-SNAPSHOT",
+  "version": "2.4.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
- [FIXED] Preserve document revisions in shallow backup.