### PR TITLE
Prepare version 2.5.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 2.5.0 (2019-10-24)
 - [UPGRADED] Upgraded @cloudant/cloudant dependency to version 4.2.2.
 - [NOTE] Updated minimum supported engine to Node.js 8 “Carbon” LTS.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.4.3-SNAPSHOT",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.4.3-SNAPSHOT",
+  "version": "2.5.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# 2.5.0 (2019-10-24)
- [UPGRADED] Upgraded @cloudant/cloudant dependency to version 4.2.2.
- [NOTE] Updated minimum supported engine to Node.js 8 “Carbon” LTS.