### PR TITLE
Prepare 2.5.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.5.1 (2019-12-06)
 - [FIXED] Issue with incorrect handling of percent-encoded user info characters
   via @cloudant/cloudant dependency.
 - [UPGRADED] Upgraded @cloudant/cloudant dependency to minimum version 4.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.1-SNAPSHOT",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.1-SNAPSHOT",
+  "version": "2.5.1",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.5.1 release

# Changes

# 2.5.1 (2019-12-06)
- [FIXED] Issue with incorrect handling of percent-encoded user info characters
  via @cloudant/cloudant dependency.
- [UPGRADED] Upgraded @cloudant/cloudant dependency to minimum version 4.2.3
- [IMPROVED] Added documentation around encoding of characters in the user info
  subcomponent of the URL.
