### PR TITLE
Prepare 2.5.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
-# 2.5.2-SNAPSHOT (2020-02-28)
-- [FIXED] Issue with compatibility with Nano 8.2.0. 
+# 2.5.2 (2020-03-02)
+- [FIXED] Issue with compatibility with Nano 8.2.0.
 
 # 2.5.1 (2019-12-06)
 - [FIXED] Issue with incorrect handling of percent-encoded user info characters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.2-SNAPSHOT",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.2-SNAPSHOT",
+  "version": "2.5.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.5.2 release

# Changes
# 2.5.2 (2020-03-02)
- [FIXED] Issue with compatibility with Nano 8.2.0.