### PR TITLE
Prepare 2.6.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.6.0 (2020-09-22)
 - [UPGRADED] Upgraded `@cloudant/cloudant` dependency to version `4.3.0`.
 - [NOTE] Updated minimum supported engine to Node.js 10 "dubnium" LTS.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.3-SNAPSHOT",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.5.3-SNAPSHOT",
+  "version": "2.6.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.6.0 release

# Changes
# 2.6.0 (2020-09-22)
- [UPGRADED] Upgraded `@cloudant/cloudant` dependency to version `4.3.0`.
- [NOTE] Updated minimum supported engine to Node.js 10 "dubnium" LTS.