### PR TITLE
detect paused queue correctly when writing to stream

### DIFF
--- a/app.js
+++ b/app.js
@@ -270,7 +270,7 @@ module.exports = {
         if (!continueWriting) {
           // The buffer was full, pause the queue to stop the writes until we
           // get a drain event
-          if (q && !q.isPaused) {
+          if (q && !q.paused) {
             q.pause();
             targetStream.once('drain', function() {
               q.resume();


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
  - _I'm employed by IBM UK, and created this fix as part of my job - can/do I need to tick the DCO?_
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

Fixes #352


## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Looks like a typo - with an `async.queue`, paused state is given by property `q.paused` - https://caolan.github.io/async/v3/docs.html#queue

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
Validated in our consuming program - nodejs warning `MaxListenersExceededWarning` is no longer emitted.

No regression test added as I'm new to this project, and don't have the time right now.

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"