### PR TITLE
382 intermittent error test

### DIFF
--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -143,8 +143,10 @@ function restoreHttpError(opts, errorName, errorCode, done) {
         // Allow the existence and _bulk_get checks to pass
         const n = nock(url).head('/fakenockdb').reply(200);
         n.post('/fakenockdb/_bulk_get').reply(200, '{"results": []}');
-        // Simulate a fatal HTTP error when trying to fetch docs (note 2 outstanding batches)
-        n.post('/fakenockdb/_bulk_get').query(true).times(2).reply(400, { error: 'bad_request', reason: 'testing bad response' });
+        // Simulate a fatal HTTP error when trying to fetch docs
+        // Note: 2 outstanding batches, so 2 responses, 1 mock is optional because we can't guarantee timing
+        n.post('/fakenockdb/_bulk_get').query(true).reply(400, { error: 'bad_request', reason: 'testing bad response' });
+        n.post('/fakenockdb/_bulk_get').query(true).optionally().reply(400, { error: 'bad_request', reason: 'testing bad response' });
         backupHttpError(p, 'HTTPFatalError', 40, done);
       });
 

--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -251,7 +251,10 @@ function restoreHttpError(opts, errorName, errorCode, done) {
         const n = nock(url).head('/fakenockdb').reply(200);
         // Simulate a 400 trying to write docs, 5 times because of default parallelism
         // Provide a body function to handle the stream, but allow any body
-        n.post('/fakenockdb/_bulk_docs', function(body) { return true; }).times(5).reply(400, { error: 'bad_request', reason: 'testing bad response' });
+        // Four of the mocks are optional because of parallelism 5 we can't guarantee that the exit will happen
+        // after all 5 requests, but we must get at least one of them
+        n.post('/fakenockdb/_bulk_docs', function(body) { return true; }).reply(400, { error: 'bad_request', reason: 'testing bad response' });
+        n.post('/fakenockdb/_bulk_docs', function(body) { return true; }).times(4).optionally().reply(400, { error: 'bad_request', reason: 'testing bad response' });
         const q = u.p(params, { opts: { bufferSize: 1 }, expectedRestoreError: { name: 'HTTPFatalError', code: 40 } });
         restoreHttpError(q, 'HTTPFatalError', 40, done);
       });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - *test only*
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Correct some intermittently failing tests.

Fixes #382

## Approach

As per #382 in some of the fatal error tests parallelism is at play and we can't guarantee to call all the mocks before the process terminates. The solution proposed here is to make all but one of the mock requests optional in these tests to allow the nock assertions to pass if the process terminates (with the correct error) before the subsequent requests.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

Test corrections as outlined above. It has been green 3 builds in a row in Jenkins (with 3 branches in each) and many many times locally. 🤞 

## Monitoring and Logging

- "No change"

