### PR TITLE
Extend preflight check in a database restore function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - [FIXED] Corrected `user-agent` header on requests.
 - [FIXED] Restore of shallow backups created with versions <=2.4.2.
 - [IMPROVED] Added quiet option to backup and restore to suppress batch messages.
+- [IMPROVED] Added a preflight check for restore function to make sure that a target database is new and empty.
 
 # 2.7.0 (2021-09-14)
 - [UPGRADED] Cloudant client dependency from `@cloudant/cloudant` to `@ibm-cloud/cloudant`.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ details them.
 
 ### `couchrestore`
 
+* `13`: restore target database is not new and empty.
+
 ## Note on attachments
 
 TLDR; If you backup a database that contains attachments you will not be able to restore it.

--- a/app.js
+++ b/app.js
@@ -176,7 +176,7 @@ function proceedIfRestoreDbValid(db, callback) {
   db.service.getDatabaseInformation({ db: db.db }).then(response => {
     const { doc_count: docCount, doc_del_count: deletedDocCount } = response.result;
     if (!db.db.startsWith("_") && (docCount !== 0 || deletedDocCount !== 0)) {
-      var notEmptyDBErr = new Error(`Database ${db.url} is not empty.`);
+      var notEmptyDBErr = new Error(`Target database ${db.url} is not empty.`);
       notEmptyDBErr.name = 'DatabaseNotEmpty';
       callback(notEmptyDBErr);
     } else {

--- a/app.js
+++ b/app.js
@@ -175,7 +175,7 @@ function proceedIfBackupDbValid(db, callback) {
 function proceedIfRestoreDbValid(db, callback) {
   db.service.getDatabaseInformation({ db: db.db }).then(response => {
     const { doc_count: docCount, doc_del_count: deletedDocCount } = response.result;
-    if (docCount !== 0 || deletedDocCount !== 0) {
+    if (!db.db.startsWith("_") && (docCount !== 0 || deletedDocCount !== 0)) {
       var notEmptyDBErr = new Error(`Database ${db.url} is not empty.`);
       notEmptyDBErr.name = 'DatabaseNotEmpty';
       callback(notEmptyDBErr);

--- a/app.js
+++ b/app.js
@@ -199,7 +199,7 @@ function proceedIfRestoreDbValid(db, callback) {
 */
 function parseIfDbValidResponseError(db, err) {
   if (err && err.status === 404) {
-    // Override the error type and mesasge for the DB not found case
+    // Override the error type and message for the DB not found case
     var msg = `Database ${db.url}` +
     `${db.db} does not exist. ` +
     'Check the URL and database name have been specified correctly.';

--- a/app.js
+++ b/app.js
@@ -175,8 +175,11 @@ function proceedIfBackupDbValid(db, callback) {
 function proceedIfRestoreDbValid(db, callback) {
   db.service.getDatabaseInformation({ db: db.db }).then(response => {
     const { doc_count: docCount, doc_del_count: deletedDocCount } = response.result;
+    // The system databases can have a validation ddoc(s) injected in them on creation.
+    // This sets the doc count off, so we just complitely exclude the system databases from this check.
+    // The assumption here is that users restoring system databases know what they are doing.
     if (!db.db.startsWith("_") && (docCount !== 0 || deletedDocCount !== 0)) {
-      var notEmptyDBErr = new Error(`Target database ${db.url} is not empty.`);
+      var notEmptyDBErr = new Error(`Target database ${db.url}${db.db} is not empty.`);
       notEmptyDBErr.name = 'DatabaseNotEmpty';
       callback(notEmptyDBErr);
     } else {

--- a/app.js
+++ b/app.js
@@ -167,7 +167,7 @@ function proceedIfBackupDbValid(db, callback) {
 }
 
 /*
-  Check the restore database exists, new and empty and that the credentials used have
+  Check that the restore database exists, is new and is empty. Also verify that the credentials used have
   visibility. Callback with a fatal error if there is a problem with the DB.
   @param {string} db - database object
   @param {function(err)} callback - error is undefined if DB exists, new and empty

--- a/includes/error.js
+++ b/includes/error.js
@@ -20,6 +20,7 @@ const codes = {
   DatabaseNotFound: 10,
   Unauthorized: 11,
   Forbidden: 12,
+  DatabaseNotEmpty: 13,
   NoLogFileName: 20,
   LogDoesNotExist: 21,
   IncompleteChangesInLogFile: 22,


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

This change extends a preflight check in a database restore function to make sure that a target database is a new and empty. It does that by confirming that the target database has 0 actual or deleted docs.

The check adds a new error `DatabaseNotEmpty` with an exit code 13.

Fixes #376 

## Approach

Function `proceedIfDbValid` got split in two version for backup and restore, where restore version was changed to check that number of docs and deleted docs in a target database is zero.

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - should terminate on `notEmptyDBErr` when database is not empty
    - should terminate on `notEmptyDBErr` when database is not new
    
- Modified existing restore tests to reflect changed validation approach

## Monitoring and Logging

- "No change"
