### PR TITLE
Prepare 2.8.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.8.0 (2021-11-25)
 - [FIXED] Corrected `user-agent` header on requests.
 - [FIXED] Restore of shallow backups created with versions <=2.4.2.
 - [IMPROVED] Added quiet option to backup and restore to suppress batch messages.
@@ -6,6 +6,7 @@
 - [IMPROVED] Added handling for errors reading log file.
 - [IMPROVED] Split changes spooling to improve reliability on databases with
   millions of documents.
+- [UPGRADED] `@ibm-cloud/cloudant`, `commander` and `debug` dependencies.
 
 # 2.7.0 (2021-09-14)
 - [UPGRADED] Cloudant client dependency from `@cloudant/cloudant` to `@ibm-cloud/cloudant`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install -g @cloudant/couchbackup
 ```
 
 ### Requirements
-* The minimum required Node.js version is 10.
+* The minimum required Node.js version is 12.
 * The minimum required CouchDB version is 2.0.0.
 
 ### Snapshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.7.1-SNAPSHOT",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.7.1-SNAPSHOT",
+  "version": "2.8.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
_Notes_:
* checking the README is part of the release process and I noticed an out-of-date Node.js version there, so this PR includes a correction for that

# Proposed 2.8.0 release

# Changes

```
# 2.8.0 (2021-11-25)
- [FIXED] Corrected `user-agent` header on requests.
- [FIXED] Restore of shallow backups created with versions <=2.4.2.
- [IMPROVED] Added quiet option to backup and restore to suppress batch messages.
- [IMPROVED] Added a preflight check for restore function to make sure that a target database is new and empty.
- [IMPROVED] Added handling for errors reading log file.
- [IMPROVED] Split changes spooling to improve reliability on databases with
  millions of documents.
- [UPGRADED] `@ibm-cloud/cloudant`, `commander` and `debug` dependencies.
```
