### PR TITLE
Ternary expansion to sh env var name

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-16T14:34:16Z",
+  "generated_at": "2021-11-30T10:44:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "90c240c0ecfb254c589319f022de059fc739c54a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 149,
         "type": "NPM tokens",
         "verified_result": null
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@
 def getEnvForSuite(suiteName) {
   // Base environment variables
   def envVars = [
-    "COUCH_BACKEND_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${SDKS_TEST_SERVER_HOST}",
     "DBCOMPARE_NAME=DatabaseCompare",
     "DBCOMPARE_VERSION=1.0.1",
     "NVM_DIR=${env.HOME}/.nvm"
@@ -25,15 +24,11 @@ def getEnvForSuite(suiteName) {
   // Add test suite specific environment variables
   switch(suiteName) {
     case 'test':
-      envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${SDKS_TEST_SERVER_HOST}")
       break
     case 'toxytests/toxy':
-      envVars.add("COUCH_URL=http://localhost:3000") // proxy
       envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
       break
       case 'test-iam':
-        envVars.add("COUCH_URL=${SDKS_TEST_SERVER_URL}")
-        envVars.add("COUCHBACKUP_TEST_IAM_API_KEY=${env.IAM_API_KEY}")
         envVars.add("CLOUDANT_IAM_TOKEN_URL=${SDKS_TEST_IAM_URL}")
         break
     default:
@@ -60,10 +55,10 @@ def setupNodeAndTest(version, filter='', testSuite='test') {
         """
       } else {
         // Run tests using creds
-        withCredentials([usernamePassword(credentialsId: 'testServerLegacy', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
+        withEnv(getEnvForSuite("${testSuite}")) {
+          withCredentials([usernamePassword(credentialsId: 'testServerLegacy', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
                           usernamePassword(credentialsId: 'artifactory', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PW'),
-                          string(credentialsId: 'testServerIamApiKey', variable: 'IAM_API_KEY')]) {
-          withEnv(getEnvForSuite("${testSuite}")) {
+                          string(credentialsId: 'testServerIamApiKey', variable: "${(testSuite == 'test-iam') ? 'COUCHBACKUP_TEST_IAM_API_KEY' : 'IAM_API_KEY'}")]) {
             try {
               // For the IAM tests we want to run the normal 'test' suite, but we
               // want to keep the report named 'test-iam'
@@ -80,8 +75,10 @@ def setupNodeAndTest(version, filter='', testSuite='test') {
                 nvm install ${version}
                 nvm use ${version}
                 npm install mocha-jenkins-reporter --save-dev
-                curl -O -u ${env.ARTIFACTORY_USER}:${env.ARTIFACTORY_PW} https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+                curl -O -u "\${ARTIFACTORY_USER}:\${ARTIFACTORY_PW}" "https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip"
                 unzip ${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+                export COUCH_BACKEND_URL="https://\${DB_USER}:\${DB_PASSWORD}@\${SDKS_TEST_SERVER_HOST}"
+                export COUCH_URL="${(testSuite == 'toxytests/toxy') ? 'http://localhost:3000' : ((testSuite == 'test-iam') ? '${SDKS_TEST_SERVER_URL}' : '${COUCH_BACKEND_URL}')}"
                 ./node_modules/mocha/bin/mocha --reporter mocha-jenkins-reporter --reporter-options junit_report_path=./test/test-results.xml,junit_report_stack=true,junit_report_name=${testSuite} ${filter} ${testRun}
               """
             } finally {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - `Jenkinsfile` changes only
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Update Jenkinsfile to avoid groovy interpolation of creds

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Run the Jenkins build.

### 2. What you expected to happen
Complete without warnings.

### 3. What actually happened
Warnings about interpolation of creds.

## Approach

Use the env vars directly instead of interpolating them into commands. This means moving some of the env setting into the `sh` step and performing some groovy switching there to keep the existing behaviours.

## Schema & API Changes

- "No change"

## Security and Privacy

- Improved best-practice for creds handling in Jenkins

## Testing

- N/A build or packaging only changes - existing tests running and passing.

## Monitoring and Logging

- "No change"
