### PR TITLE
Increase 25M spooling test timeout

### DIFF
--- a/test/spoolchanges.js
+++ b/test/spoolchanges.js
@@ -125,8 +125,8 @@ describe('#unit Check spool changes', function() {
 
 describe('Longer spool changes checks', function() {
   it('#slow should keep collecting changes (25M)', function(done) {
-    // This test might take up to 2 minutes
-    this.timeout(2 * 60 * 1000);
+    // This test might take up to 5 minutes
+    this.timeout(5 * 60 * 1000);
     // Note changes spooling uses a constant batch size, we are setting
     // a test value here and setting the buffer to match
     const batch = 100000;


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - test only
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes - test only
- [x] Completed the PR template below:

## Description

The 25M spool changes test is intermittently timing out in Jenkins executor environment.

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Run the test.

### 2. What you expected to happen
Test to pass.

### 3. What actually happened
Test sometimes times out.

## Approach

Increase the test timeout from 2 to 5 minutes. It will still finish faster when it can, but this will avoid intermittent failures when the executor is not performing as fast as usual.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing test to incease timeout.

## Monitoring and Logging

- "No change"
