### PR TITLE
Fix NPM_TOKEN Groovy interpolation warning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-30T10:44:20Z",
+  "generated_at": "2021-12-01T09:41:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -79,8 +79,7 @@
   "results": {
     "Jenkinsfile": [
       {
-        "hashed_secret": "90c240c0ecfb254c589319f022de059fc739c54a",
-        "is_secret": false,
+        "hashed_secret": "8e494667a94be484abba2c4d4cf9bea0c3eb39ea",
         "is_verified": false,
         "line_number": 149,
         "type": "NPM tokens",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ stage('Publish') {
         // 2. add the build ID to any snapshot version for uniqueness
         // 3. publish the build to NPM adding a snapshot tag if pre-release
         sh """
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+          echo '//registry.npmjs.org/:_authToken=\${NPM_TOKEN}' > .npmrc
           ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
           npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
         """


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Update Jenkinsfile to avoid groovy interpolation of `NPM_TOKEN`

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Run the Jenkins build
### 2. What you expected to happen
Complete without the following warning:
```
The following steps that have been detected may have insecure interpolation of sensitive variables (click here for an explanation):
sh: [NPM_TOKEN]
```
### 3. What actually happened
A warning about interpolation of `NPM_TOKEN`.

## Approach

Use the `NPM_TOKEN` env var directly instead of interpolating it into the commands.

## Schema & API Changes

- "No change"

## Security and Privacy

Improved best-practice for creds handling in Jenkins


## Testing

* N/A build or packaging only changes - existing tests running and passing.


## Monitoring and Logging

- "No change"
