### PR TITLE
Prepare 2.8.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 2.8.1 (2021-12-02)
 - [FIXED] Regression from version 2.7 resulting in incorrect handling of percent-encoded credentials in the URL user-info.
-  
+
 # 2.8.0 (2021-11-25)
 - [FIXED] Corrected `user-agent` header on requests.
 - [FIXED] Restore of shallow backups created with versions <=2.4.2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.1-SNAPSHOT",
+  "version": "2.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.1-SNAPSHOT",
+  "version": "2.8.1",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.8.1 release

# Changes

```
# 2.8.1 (2021-12-02)
- [FIXED] Regression from version 2.7 resulting in incorrect handling of percent-encoded credentials in the URL user-info.
```
