### PR TITLE
Prepare 2.8.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.8.2 (2022-02-10)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.0.24`.
+
 # 2.8.1 (2021-12-02)
 - [FIXED] Regression from version 2.7 resulting in incorrect handling of percent-encoded credentials in the URL user-info.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.2-SNAPSHOT",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.2-SNAPSHOT",
+  "version": "2.8.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.8.2 release

# Changes

# 2.8.2 (2022-02-10)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.0.24`.