### PR TITLE
Prepare 2.8.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 2.8.3 (2022-04-05)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.1`.
 - [NOTE] Move `retry-axios` and `ibm-cloud-sdk-core` to peerDependencies.
-- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.0.25`.
 
 # 2.8.2 (2022-02-10)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.0.24`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.3-SNAPSHOT",
+  "version": "2.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.8.3-SNAPSHOT",
+  "version": "2.8.3",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.8.3 release

# Changes

# 2.8.3 (2022-04-04)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.1`.
- [NOTE] Move `retry-axios` and `ibm-cloud-sdk-core` to peerDependencies.