### PR TITLE
Update Node engine to 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "12"
-  - "10"
+  - "14"
+  - "16"
 install: npm install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [NOTE] Updated minimum supported engine to Node.js 14 `fermium` LTS.
+
 # 2.8.3 (2022-04-05)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.1`.
 - [NOTE] Move `retry-axios` and `ibm-cloud-sdk-core` to peerDependencies.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,13 +115,13 @@ stage('QA') {
   }
 
   def axes = [
-    Node12x:{ setupNodeAndTest('12', filter) }, // 12.x Maintenance LTS
-    Node14x:{ setupNodeAndTest('14', filter) }, // 14.x Active LTS
-    Node:{ setupNodeAndTest('16', filter) }, // Current
+    Node14x:{ setupNodeAndTest('14', filter) }, // 14.x Maintenance LTS
+    Node16x:{ setupNodeAndTest('16', filter) }, // 16.x Active LTS
+    Node:{ setupNodeAndTest('18', filter) }, // Current
     // Test IAM on the current Node.js version. Filter out unit tests and the
     // slowest integration tests.
     Iam: { setupNodeAndTest('16', '-i -g \'#unit|#slowe\'', 'test-iam') },
-    Lint: { setupNodeAndTest('12', '', 'lint') }
+    Lint: { setupNodeAndTest('14', '', 'lint') }
   ]
   // Add unreliable network tests if specified
   if (env.RUN_TOXY_TESTS && env.RUN_TOXY_TESTS.toBoolean()) {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install -g @cloudant/couchbackup
 ```
 
 ### Requirements
-* The minimum required Node.js version is 12.
+* The minimum required Node.js version is 14.
 * The minimum required CouchDB version is 2.0.0.
 
 ### Snapshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "ibm-cloud-sdk-core": "^2.17.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "@ibm-cloud/cloudant": "0.1.2",


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - no test needed
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Fixes #471 

Update minimum node engine requirement from 12 to 14 and Node.js versions in test matrix.

## Approach

Update engine requirement to `"node": ">=14"`

Made the changes based on the previous node engine update: https://github.com/cloudant/couchbackup/pull/364

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

No change

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

No change

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

Test with Node.js supported LTS versions `14` and `16` and current version 18.

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging

No change
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
