### PR TITLE
Prepare 2.9.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.9.1 (2022-07-19)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.4`.
+
 # 2.9.0 (2022-05-09)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.2`.
 - [NOTE] Updated minimum supported engine to Node.js 14 `fermium` LTS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.1-SNAPSHOT",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.1-SNAPSHOT",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.1-SNAPSHOT",
+  "version": "2.9.1",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.1 release

# Changes

# 2.9.1 (2022-07-19)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.4`.