### PR TITLE
Proposed 2.9.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.9.2 (2022-08-02)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.5`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `3.1.0`.
+
 # 2.9.1 (2022-07-19)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.4`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.2-SNAPSHOT",
+  "version": "2.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.2-SNAPSHOT",
+  "version": "2.9.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.2 release

# Changes

# 2.9.2 (2022-08-02)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.1.5`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `3.1.0`.
