### PR TITLE
ci: check branch name for snapshot publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ stage('QA') {
 
 // Publish the primary branch
 stage('Publish') {
-  if (env.BRANCH_IS_PRIMARY) {
+  if (env.BRANCH_NAME == 'main') {
     node('sdks-backup-executor') {
       unstash 'built'
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/main/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - build only
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes - build only
- [x] Completed the PR template below:

## Description

#495 didn't work as expected and the `BRANCH_IS_PRIMARY` check doesn't seem to work for scripted pipeline checkout of the new `main` default branch.

## Approach

Revert to using a branch name check, but ofc use the new default branch name of `main`.
I tested the change on a replay of the last `main` build and the name check correctly produced a snapshot.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
