### PR TITLE
Update version to 2.9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 2.9.4
+# 2.9.4 (2022-10-05)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.2.1`.
 - [NOTE] Add `axios` to peerDependencies.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.4-SNAPSHOT",
+  "version": "2.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.4-SNAPSHOT",
+  "version": "2.9.4",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.4 release

# Changes
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.2.1`.
- [NOTE] Add `axios` to peerDependencies.