### PR TITLE
Proposed 2.9.5 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.9.5 (2022-11-01)
+- [UPGRADED]  `@ibm-cloud/cloudant` dependency to version `0.3.0`.
+
 # 2.9.4 (2022-10-05)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.2.1`.
 - [NOTE] Add `axios` to peerDependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.5-SNAPSHOT",
+  "version": "2.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.5-SNAPSHOT",
+  "version": "2.9.5",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.5 release

# Changes

# 2.9.5 (2022-11-01)
- [UPGRADED]  `@ibm-cloud/cloudant` dependency to version `0.3.0`.