### PR TITLE
fix file descriptor leak in backup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [FIXED] Discard temporary file descriptor for backup.
+
 # 2.9.5 (2022-11-01)
 - [UPGRADED]  `@ibm-cloud/cloudant` dependency to version `0.3.0`.
 

--- a/includes/config.js
+++ b/includes/config.js
@@ -24,7 +24,7 @@ function apiDefaults() {
     parallelism: 5,
     bufferSize: 500,
     requestTimeout: 120000,
-    log: tmp.fileSync().name,
+    log: tmp.tmpNameSync(),
     resume: false,
     mode: 'full'
   };


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/main/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Replace `tmp.fileSync().name` in [apiDefaults](https://github.com/cloudant/couchbackup/blob/f44a8a3fe2967cd33e32dd911b699f019bbee1a4/includes/config.js#L27) with `tmp.tmpNameSync()` to discard descriptor of temporary file during backup.

fixes #535 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Update `tmp` call in `includes/config.js`
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Used this [gist](https://gist.github.com/emlaver/9239ce5e12182e158b00739825a9e89b) to verify that file descriptors are discarded once backup completes.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
