### PR TITLE
Prepare 2.9.6 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
-# Unreleased
+# 2.9.6 (2023-01-06)
+- [FIXED] HTTP client dependency issue that masked backup errors when server connection was dropped.
 - [FIXED] Discard temporary file descriptor for backup.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.4.0`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.2` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to minimum version `1.2.1` to match version provided from `ibm-cloud-sdk-core`.
 
 # 2.9.5 (2022-11-01)
 - [UPGRADED]  `@ibm-cloud/cloudant` dependency to version `0.3.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.6-SNAPSHOT",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.6-SNAPSHOT",
+  "version": "2.9.6",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.6 release

# Changes

# 2.9.6 (2023-01-06)
- [FIXED] HTTP client dependency issue that masked backup errors when server connection was dropped.
- [FIXED] Discard temporary file descriptor for backup.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.4.0`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.2` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to minimum version `1.2.1` to match version provided from `ibm-cloud-sdk-core`.
