### PR TITLE
Update version to 2.9.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.9.8 (2023-04-04)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.0`.
+
 # 2.9.7 (2023-02-27)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.4.1`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `4.0.3`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.8-SNAPSHOT",
+  "version": "2.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.8-SNAPSHOT",
+  "version": "2.9.8",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.8 release

# Changes
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.0`.