### PR TITLE
Update version to 2.9.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.9.9 (2023-05-03)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.1`.
+- [NOTE] Updated minimum supported engine to Node.js 16 `gallium` LTS.
+
 # 2.9.8 (2023-04-04)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.0`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.9-SNAPSHOT",
+  "version": "2.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.9-SNAPSHOT",
+  "version": "2.9.9",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/cloudant/couchbackup",
   "repository": "https://github.com/cloudant/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.9 release

# Changes
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.1`.
- [NOTE] Updated minimum supported engine to Node.js 16 `gallium` LTS.